### PR TITLE
Updated PR for the printer design proposal

### DIFF
--- a/include/seqan3/alignment/matrix/detail/advanceable_alignment_coordinate.hpp
+++ b/include/seqan3/alignment/matrix/detail/advanceable_alignment_coordinate.hpp
@@ -294,23 +294,26 @@ public:
 namespace seqan3
 {
 
-/*!\brief A seqan3::detail::advanceable_alignment_coordinate can be printed to the seqan3::debug_stream.
- * \tparam    coordinate_type The alignment coordinate type.
- * \param[in] s               The seqan3::debug_stream.
- * \param[in] c               The alignment coordinate to print.
- * \relates seqan3::debug_stream_type
+/*!\brief The printer for seqan3::detail::advanceable_alignment_coordinate.
  *
- * \details
+ * Prints the alignment coordinate as a tuple of the column and row index.
  *
- * Prints the alignment coordinate as a tuple.
+ * \tparam state_t The state of the detail::advanceable_alignment_coordinate.
+ * \ingroup alignment_matrix
  */
-template <typename char_t, typename coordinate_type>
-    requires detail::is_value_specialisation_of_v<std::remove_cvref_t<coordinate_type>,
-                                                  detail::advanceable_alignment_coordinate>
-inline debug_stream_type<char_t> & operator<<(debug_stream_type<char_t> & s, coordinate_type && c)
+template <auto state_t>
+struct advanceable_alignment_coordinate_printer<detail::advanceable_alignment_coordinate<state_t>>
 {
-    s << std::tie(c.first, c.second);
-    return s;
-}
+    /*!\brief The function call operator that prints the coordinate to the given stream.
+     * \tparam stream_t The type of the stream.
+     * \param[in,out] stream The stream to print to.
+     * \param[in] arg The alignment coordinate to print.
+     */
+    template <typename stream_t>
+    constexpr void operator()(stream_t & stream, detail::advanceable_alignment_coordinate<state_t> const arg) const
+    {
+        stream << std::tie(arg.first, arg.second);
+    }
+};
 
 } // namespace seqan3

--- a/include/seqan3/alignment/matrix/detail/trace_directions.hpp
+++ b/include/seqan3/alignment/matrix/detail/trace_directions.hpp
@@ -9,8 +9,12 @@
 
 #pragma once
 
+#include <array>
+#include <string_view>
+
 #include <seqan3/core/add_enum_bitwise_operators.hpp>
 #include <seqan3/core/debug_stream/debug_stream_type.hpp>
+#include <seqan3/core/detail/template_inspection.hpp>
 
 namespace seqan3::detail
 {
@@ -54,12 +58,7 @@ template <>
 inline constexpr bool add_enum_bitwise_operators<seqan3::detail::trace_directions> = true;
 //!\endcond
 
-/*!\brief All trace_directions can be printed as ascii or as utf8 to the seqan3::debug_stream.
- * \param s The seqan3::debug_stream.
- * \param trace The trace direction.
- * \relates seqan3::debug_stream_type
- *
- * \details
+/*!\brief Prints `trace_directions` as ascii or as utf8 to output stream.
  *
  * The following table shows the printed symbol of a particular seqan3::detail::trace_directions:
  *
@@ -71,23 +70,71 @@ inline constexpr bool add_enum_bitwise_operators<seqan3::detail::trace_direction
  * | seqan3::detail::trace_directions::up        | ⇡    | u     |
  * | seqan3::detail::trace_directions::left_open | ←    | L     |
  * | seqan3::detail::trace_directions::left      | ⇠    | l     |
+ *
+ * \ingroup alignment_matrix
  */
-template <typename char_t>
-inline debug_stream_type<char_t> & operator<<(debug_stream_type<char_t> & s, detail::trace_directions const trace)
+template <>
+struct trace_directions_printer<detail::trace_directions>
 {
-    static char const * unicode[32]{"↺",   "↖",    "↑",   "↖↑",  "⇡",    "↖⇡",   "↑⇡",  "↖↑⇡",  "←",    "↖←",   "↑←",
-                                    "↖↑←", "⇡←",   "↖⇡←", "↑⇡←", "↖↑⇡←", "⇠",    "↖⇠",  "↑⇠",   "↖↑⇠",  "⇡⇠",   "↖⇡⇠",
-                                    "↑⇡⇠", "↖↑⇡⇠", "←⇠",  "↖←⇠", "↑←⇠",  "↖↑←⇠", "⇡←⇠", "↖⇡←⇠", "↑⇡←⇠", "↖↑⇡←⇠"};
+private:
+    //!\brief The unicode representation of the trace directions.
+    static constexpr std::array<std::string_view, 32> unicode{
+        "↺", "↖",  "↑",  "↖↑",  "⇡",  "↖⇡",  "↑⇡",  "↖↑⇡",  "←",  "↖←",  "↑←",  "↖↑←",  "⇡←",  "↖⇡←",  "↑⇡←",  "↖↑⇡←",
+        "⇠", "↖⇠", "↑⇠", "↖↑⇠", "⇡⇠", "↖⇡⇠", "↑⇡⇠", "↖↑⇡⇠", "←⇠", "↖←⇠", "↑←⇠", "↖↑←⇠", "⇡←⇠", "↖⇡←⇠", "↑⇡←⇠", "↖↑⇡←⇠"};
 
-    static char const * csv[32]{"N",   "D",    "U",   "DU",  "u",    "Du",   "Uu",  "DUu",  "L",    "DL",   "UL",
-                                "DUL", "uL",   "DuL", "UuL", "DUuL", "l",    "Dl",  "Ul",   "DUl",  "ul",   "Dul",
-                                "Uul", "DUul", "Ll",  "DLl", "ULl",  "DULl", "uLl", "DuLl", "UuLl", "DUuLl"};
+    //!\brief The ascii representation of the trace directions.
+    static constexpr std::array<std::string_view, 32> csv{
+        "N", "D",  "U",  "DU",  "u",  "Du",  "Uu",  "DUu",  "L",  "DL",  "UL",  "DUL",  "uL",  "DuL",  "UuL",  "DUuL",
+        "l", "Dl", "Ul", "DUl", "ul", "Dul", "Uul", "DUul", "Ll", "DLl", "ULl", "DULl", "uLl", "DuLl", "UuLl", "DUuLl"};
 
-    bool is_unicode = (s.flags2() & fmtflags2::utf8) == fmtflags2::utf8;
-    auto const & trace_dir = is_unicode ? unicode : csv;
+public:
+    /*!\brief Prints the trace directions into the given stream.
+     *
+     * This overload is only available if the stream has a member function `flags2` that returns a `fmtflags2`.
+     * Using the flags2() member function allows to print the trace with unicode characters if seqan3::fmtflags2::utf8
+     * is set to the seqan3::debug_stream.
+     *
+     * \tparam stream_t The type of the stream.
+     * \param stream The stream to print to.
+     * \param trace The trace directions to print.
+     */
+    template <typename stream_t>
+        requires detail::is_type_specialisation_of_v<stream_t, debug_stream_type>
+    constexpr void operator()(stream_t & stream, detail::trace_directions const trace) const
+    {
+        print_impl(stream, stream.flags2(), trace);
+    }
 
-    s << trace_dir[static_cast<size_t>(trace)];
-    return s;
-}
+    /*!\brief Prints the trace directions into the given stream.
+     *
+     * This overload is only available if the stream has no member function `flags2`. In this case it will use
+     * ascii characters to print the trace.
+     *
+     * \tparam stream_t The type of the stream.
+     * \param stream The stream to print to.
+     * \param trace The trace directions to print.
+     */
+    template <typename stream_t>
+    constexpr void operator()(stream_t & stream, detail::trace_directions const trace) const
+    {
+        print_impl(stream, fmtflags2::none, trace);
+    }
+
+private:
+    /*!\brief Prints the trace directions
+     * \tparam stream_t The type of the stream.
+     * \param stream The stream to print to.
+     * \param flag The flags of the stream.
+     * \param trace The trace directions to print.
+     */
+    template <typename stream_t>
+    constexpr void print_impl(stream_t & stream, fmtflags2 const flag, detail::trace_directions const trace) const
+    {
+        bool const is_unicode = (flag & fmtflags2::utf8) == fmtflags2::utf8;
+        auto const & trace_dir = is_unicode ? unicode : csv;
+
+        stream << trace_dir[static_cast<size_t>(trace)];
+    }
+};
 
 } // namespace seqan3

--- a/include/seqan3/alphabet/cigar/cigar.hpp
+++ b/include/seqan3/alphabet/cigar/cigar.hpp
@@ -207,13 +207,26 @@ public:
     //!\}
 };
 
-//!\brief Overload for the seqan3::debug_stream's operator.
-template <typename char_t>
-inline debug_stream_type<char_t> & operator<<(debug_stream_type<char_t> & s, cigar const c)
+/*!\brief The printer used for formatted output of the cigar alphabets.
+ *
+ * The type of the printer must be a seqan3::cigar type.
+ *
+ * \ingroup alphabet_cigar
+ */
+template <>
+struct cigar_printer<cigar>
 {
-    s << c.to_string();
-    return s;
-}
+    /*!\brief Prints the formatted output of the cigar symbol to the stream.
+     * \tparam stream_t The type of the stream.
+     * \param[in,out] stream The output stream.
+     * \param[in] arg The cigar symbol to print.
+     */
+    template <typename stream_t>
+    constexpr void operator()(stream_t & stream, cigar const arg) const noexcept
+    {
+        stream << arg.to_string();
+    }
+};
 
 inline namespace literals
 {

--- a/include/seqan3/alphabet/concept.hpp
+++ b/include/seqan3/alphabet/concept.hpp
@@ -1065,8 +1065,7 @@ concept writable_alphabet = alphabet<t> && writable_semialphabet<t> && requires 
  *
  * \{
  */
-/*!
- * \brief Save an alphabet letter to stream.
+/*!\brief Save an alphabet letter to stream.
  * \tparam archive_t Must satisfy seqan3::cereal_output_archive.
  * \tparam alphabet_t Type of l; must satisfy seqan3::semialphabet.
  * \param l The alphabet letter.

--- a/include/seqan3/alphabet/detail/debug_stream_alphabet.hpp
+++ b/include/seqan3/alphabet/detail/debug_stream_alphabet.hpp
@@ -15,38 +15,53 @@
 
 namespace seqan3
 {
-/*!\name Formatted output overloads
- * \{
+
+/*!\brief The printer used for formatted output of seqan3::alphabet types.
+ *
+ * Prints the char representation of the given alphabet letter.
+ *
+ * \tparam alphabet_t The type of the alphabet to be printed.
+ * \ingroup alphabet
  */
-/*!\brief All alphabets can be printed to the seqan3::debug_stream by their char representation.
- * \tparam alphabet_t Type of the alphabet to be printed; must model seqan3::alphabet.
- * \param s The seqan3::debug_stream.
- * \param l The alphabet letter.
- * \relates seqan3::debug_stream_type
- */
-template <typename char_t, alphabet alphabet_t>
-inline debug_stream_type<char_t> & operator<<(debug_stream_type<char_t> & s, alphabet_t && l)
-    requires (!output_stream_over<std::basic_ostream<char_t>, alphabet_t>)
+template <alphabet alphabet_t>
+struct alphabet_printer<alphabet_t>
 {
-    return s << to_char(l);
-}
+    /*!\brief Print the alphabet to the stream
+     * \tparam stream_t The type of the stream.
+     * \param[in,out] stream The stream to print to.
+     * \param[in] letter The alphabet letter.
+     */
+    template <typename stream_t>
+    constexpr void operator()(stream_t & stream, alphabet_t const letter) const noexcept
+    {
+        stream << to_char(letter);
+    }
+};
 
 // forward declare seqan3::mask
 class mask;
 
-/*!\brief Overload for the seqan3::mask alphabet.
- * \tparam char_t Type char type of the debug_stream.
- * \param s The seqan3::debug_stream.
- * \param l The mask alphabet letter.
- * \relates seqan3::debug_stream_type
+/*!\brief The printer used for formatted output of seqan3::mask alphabet.
+ *
+ * Prints "MASKED" if the letter is masked and "UNMASKED" otherwise.
+ *
+ * \tparam mask_t The type of the alphabet to be printed. Must be seqan3::mask.
+ * \ingroup alphabet_mask
  */
-template <typename char_t, seqan3::semialphabet alphabet_t>
-inline debug_stream_type<char_t> & operator<<(debug_stream_type<char_t> & s, alphabet_t && l)
-    requires std::same_as<std::remove_cvref_t<alphabet_t>, mask>
+template <std::same_as<mask> mask_t>
+struct mask_printer<mask_t>
 {
-    return s << (l == alphabet_t{} ? "UNMASKED" : "MASKED");
-}
-
-//!\}
+    /*!\brief Print the mask alphabet to the stream
+     * \tparam stream_t The type of the stream.
+     * \param[in,out] stream The stream to print to.
+     * \param[in] arg The mask alphabet letter.
+     */
+    template <typename stream_t>
+    constexpr void operator()(stream_t & stream, mask_t const arg) const noexcept
+    {
+        // seqan3::mask is incomplete at this point, so we cannot use `arg == mask{}`
+        stream << (arg == mask_t{} ? "UNMASKED" : "MASKED");
+    }
+};
 
 } // namespace seqan3

--- a/include/seqan3/argument_parser/auxiliary.hpp
+++ b/include/seqan3/argument_parser/auxiliary.hpp
@@ -201,33 +201,39 @@ concept argument_parser_compatible_option =
     input_stream_over<std::istringstream, option_type> || named_enumeration<option_type>;
 //!\endcond
 
-/*!\name Formatted output overloads
- * \{
- */
 /*!\brief A type (e.g. an enum) can be made debug streamable by customizing the seqan3::enumeration_names.
- * \tparam option_type Type of the enum to be printed.
- * \param s  The seqan3::debug_stream.
- * \param op The value to print.
- * \relates seqan3::debug_stream_type
- *
- * \details
  *
  * This searches the seqan3::enumeration_names of the respective type for the value \p op and prints the
  * respective string if found or '\<UNKNOWN_VALUE\>' if the value cannot be found in the map.
+ *
+ * \tparam enum_t Type of the enum to be printed; must model seqan3::named_enumeration.
+ * \ingroup argument_parser
  */
-template <typename char_t, typename option_type>
-    requires named_enumeration<std::remove_cvref_t<option_type>>
-inline debug_stream_type<char_t> & operator<<(debug_stream_type<char_t> & s, option_type && op)
+template <named_enumeration enum_t>
+struct enumeration_printer<enum_t>
 {
-    for (auto & [key, value] : enumeration_names<option_type>)
+    /*!\brief Prints the associated label of the given enum value.
+     * \tparam stream_t The type of the stream.
+     * \param[in,out] stream The output stream.
+     * \param[in] arg The enum value to print.
+     *
+     * If for the given enumeration value no enumeration name can be found, "<UNKNOWN_VALUE>" is printed.
+     */
+    template <typename stream_t>
+    constexpr void operator()(stream_t & stream, enum_t const arg) const
     {
-        if (op == value)
-            return s << key;
-    }
+        for (auto & [label, enumerator] : enumeration_names<enum_t>)
+        {
+            if (arg == enumerator)
+            {
+                stream << label;
+                return;
+            }
+        }
 
-    return s << "<UNKNOWN_VALUE>";
-}
-//!\}
+        stream << "<UNKNOWN_VALUE>";
+    }
+};
 
 /*!\brief Used to further specify argument_parser options/flags.
  * \ingroup argument_parser

--- a/include/seqan3/core/debug_stream/byte.hpp
+++ b/include/seqan3/core/debug_stream/byte.hpp
@@ -16,23 +16,22 @@
 
 namespace seqan3
 {
-/*!\name Formatted output overloads
- * \{
- */
 /*!\brief A std::byte can be printed by printing its value as integer.
- * \tparam    byte_type     The type of the input; must be equal to `std::byte`.
- * \param[in] s             The seqan3::debug_stream.
- * \param[in] arg           The std::byte.
- * \relates seqan3::debug_stream_type
+ * \ingroup core_debug_stream
  */
-template <typename char_t, typename byte_type>
-    requires std::same_as<std::remove_cvref_t<byte_type>, std::byte>
-inline debug_stream_type<char_t> & operator<<(debug_stream_type<char_t> & s, byte_type && arg)
+template <>
+struct std_byte_printer<std::byte>
 {
-    s << std::to_integer<uint8_t>(arg);
-    return s;
-}
-
-//!\}
+    /*!\brief Prints the byte as uint8_t value.
+     * \tparam stream_t The type of the stream.
+     * \param[in,out] stream The output stream.
+     * \param[in] arg The byte argument to print.
+     */
+    template <typename stream_t>
+    constexpr void operator()(stream_t & stream, std::byte const arg) const
+    {
+        stream << std::to_integer<uint8_t>(arg);
+    }
+};
 
 } // namespace seqan3

--- a/include/seqan3/core/debug_stream/default_printer.hpp
+++ b/include/seqan3/core/debug_stream/default_printer.hpp
@@ -1,0 +1,236 @@
+// SPDX-FileCopyrightText: 2006-2024 Knut Reinert & Freie Universität Berlin
+// SPDX-FileCopyrightText: 2016-2024 Knut Reinert & MPI für molekulare Genetik
+// SPDX-License-Identifier: BSD-3-Clause
+
+/*!\file
+ * \author Marcel Ehrhardt <marcel.ehrhardt AT fu-berlin.de>
+ * \brief Provides seqan3::default_printer.
+ */
+
+#pragma once
+
+#include <functional>
+#include <iosfwd>
+#include <tuple>
+#include <utility>
+
+#include <seqan3/core/platform.hpp>
+
+namespace seqan3
+{
+
+// clang-format off
+/*!\brief A tag that indicates that no printer was found for the given type.
+ * \ingroup core_debug_stream
+ */
+struct no_printer_found{};
+template <typename> struct advanceable_alignment_coordinate_printer {};
+template <typename> struct alignment_matrix_printer {};
+template <typename> struct alignment_printer {};
+template <typename> struct alignment_result_printer {};
+template <typename> struct alphabet_printer {};
+template <typename> struct cigar_printer {};
+template <typename> struct debug_stream_printer {};
+template <typename> struct dynamic_bitset_printer {};
+template <typename> struct enumeration_printer {};
+template <typename> struct input_range_printer {};
+template <typename> struct integer_sequence_printer {};
+template <typename> struct integral_printer {};
+template <typename> struct mask_printer {};
+template <typename> struct optional_printer {};
+template <typename> struct sam_flag_printer {};
+template <typename> struct sequence_printer {};
+template <typename> struct search_result_printer {};
+template <typename> struct simd_printer {};
+template <typename> struct std_byte_printer {};
+template <typename> struct std_variant_printer {};
+template <typename> struct std_printer {};
+template <typename> struct strong_type_printer {};
+template <typename> struct char_sequence_printer {};
+template <typename> struct trace_directions_printer {};
+template <typename> struct tuple_printer {};
+// clang-format on
+
+/*!
+ * \interface seqan3::printable_with <>
+ * \brief The concept for a printable object.
+ *
+ * A printable object is a printer that can print an argument to a stream.
+ * The printer must be invocable with a stream and an argument.
+ *
+ * \tparam printer_t The type of the printer.
+ * \tparam stream_t The type of the stream.
+ * \tparam arg_t The type of the argument.
+ * \ingroup core_debug_stream
+ */
+template <typename printer_t, typename stream_t, typename arg_t>
+concept printable_with = std::invocable<printer_t, stream_t, arg_t>;
+
+/*!\brief The printer for standard output streams.
+ *
+ * The std_printer is used as a generic fallback to print regular types that can be printed to a
+ * standard output stream, e.g. std::cout.
+ *
+ * \tparam type_t The type of the printable argument.
+ * \ingroup core_debug_stream
+ */
+template <typename type_t>
+    requires requires (std::ostream & cout, type_t const & value) {
+        { cout << value };
+    }
+struct std_printer<type_t>
+{
+    /*!\brief The function call operator that prints the value to the stream.
+     *
+     * This function call operator prints the value to underlying stream of the seqan3::debug_stream.
+     * This overload is only provided if the stream is a seqan3::debug_stream.
+     *
+     * \tparam stream_t The type of the stream.
+     * \tparam arg_t The type of the argument.
+     * \param[in,out] stream The stream to print to.
+     * \param[in] arg The value to print.
+     */
+    template <typename stream_t, typename arg_t>
+        requires requires (stream_t & stream) { stream.stream; }
+    constexpr void operator()(stream_t & stream, arg_t && arg) const
+    {
+        *stream.stream << arg;
+    }
+};
+
+/*!
+ 8 \brief The printer for integral types.
+ *
+ * The integral_printer is used to print integral types to a stream.
+ *
+ * \tparam integral_t The type of the integral.
+ * \ingroup core_debug_stream
+ */
+template <std::integral integral_t>
+struct integral_printer<integral_t>
+{
+    /*!\brief The function call operator that prints the integral to the stream.
+     * \tparam stream_t The type of the stream.
+     * \param[in,out] stream The stream to print to.
+     * \param[in] arg The integral to print.
+     */
+    template <typename stream_t>
+    constexpr void operator()(stream_t & stream, integral_t const arg) const
+    {
+        // note that we assume here that we always can print all std::integral's,
+        // but this is not correct since std::cout << char32_t{5}; is not possible.
+        // since char32_t is also an alphabet, we avoid infinite recursion here.
+        if constexpr (printable_with<std_printer<integral_t>, stream_t &, integral_t>)
+            std::invoke(std_printer<integral_t>{}, stream, arg);
+        else
+            static_assert(std::same_as<integral_t *, void>, "This type is not printable.");
+        // We actually want `static_assert(false, "This type is not printable.");`.
+        // But this only works starting with GCC13. Before that, also the `if constexpr` branches that are not taken
+        // are evaluated and `static_assert(false)` will always result in an error. As a pre-GCC13 workaround,
+        // we can make the `false` dependent on some template type, which then will only be evaluated if the branch is
+        // taken.
+    }
+};
+
+/*!\brief The printer_order is a variadic template that defines the order of the printers.
+ *
+ * The printer_order is a variadic template that defines the order of the printers.
+ * It is used to find the first valid printer among all given printers that can print the argument to the given stream.
+ * The printer_order is used by the seqan3::default_printer.
+ *
+ * \tparam printer_templates_t The printer class templates that are used to print the arguments.
+ * \ingroup core_debug_stream
+ */
+template <template <typename> typename... printer_templates_t>
+struct printer_order
+{
+protected:
+    /*!\brief Find the index of the first printer that can print the argument.
+     * \tparam stream_t The type of the stream.
+     * \tparam arg_t The type of the argument.
+     * \tparam printers_t The printer class templates that are used to print the arguments.
+     * \returns The index of the printer that can print the argument or `n`, where `n` is equal to the
+     * number of printers, if no printer was found.
+     */
+    template <typename stream_t, typename arg_t, typename... printers_t>
+    static constexpr size_t find_index()
+    {
+        size_t i = 0;
+        return ((printable_with<printers_t, stream_t, arg_t> ? false : ++i) && ...) ? sizeof...(printer_templates_t)
+                                                                                    : i;
+    }
+
+    /*!\brief The type of the printer that can print the argument to the stream.
+     *
+     * In case no valid printer is found for the argument and stream type the seqan3::no_printer_found is used.
+     *
+     * \tparam stream_t The type of the stream.
+     * \tparam arg_t The type of the argument.
+     * \tparam i The index of the printer that can print the argument (default initialised to the index of the printer
+     * in the list that can print the argument to the stream).
+     */
+    template <typename stream_t,
+              typename arg_t,
+              size_t i = find_index<stream_t, arg_t, printer_templates_t<arg_t>...>()>
+    using printer_for_t =
+        // first: the index of the printer that can print the arguments or sizeof...(printers_t) if no printer was found
+        // second: the tuple of instantiated printers extended with no_printer_found
+        std::tuple_element_t<i, std::tuple<printer_templates_t<arg_t>..., no_printer_found>>;
+};
+
+/*!\brief The default printer that is used by seqan3::debug_stream.
+ *
+ * This printer offers a function call operator if the type is printable by one of the printers defined
+ * in the seqan3::printer_order.
+ * If no valid printer is found the function call operator is not defined.
+ *
+ * \ingroup core_debug_stream
+ */
+struct default_printer :
+    public printer_order<
+        debug_stream_printer,
+        alignment_result_printer,                 // type seqan3::alignment_result<>
+        search_result_printer,                    // type seqan3::search_result<>
+        alignment_printer,                        // concept seqan3::tuple_like<>
+        advanceable_alignment_coordinate_printer, // type seqan3::detail::advanceable_alignment_coordinate<>
+        alignment_matrix_printer,                 // concept seqan3::detail::matrix<>
+        trace_directions_printer,                 // type seqan3::detail::trace_directions
+        mask_printer,                             // type seqan3::mask
+        integral_printer,                         // concept std::integral
+        cigar_printer,                            // type seqan3::cigar
+        // NOTE: alphabet_printer needs the integral_printer overload, otherwise it might have infinite recursion due to
+        // char and uint being an alphabet
+        alphabet_printer,         // concept seqan3::alphabet
+        sam_flag_printer,         // type seqan3::sam_flag
+        simd_printer,             // concept simd::simd_concept<>
+        dynamic_bitset_printer,   // type seqan3::dynamic_bitset<>
+        char_sequence_printer,    // concept std::range::input_range<> with char value_type
+        integer_sequence_printer, // concept std::range::input_range<> with std::integral value_type
+        sequence_printer, // concept seqan3::sequence<>, i.e. std::range::input_range<> with seqan3::alphabet value_type
+        input_range_printer, // concept std::range::input_range<>
+        strong_type_printer, // concept seqan3::detail::derived_from_strong_type<>
+        optional_printer,    // type std::optional<> or std::nullopt_t
+        enumeration_printer, // types for which seqan3::enumeration_names is overloaded
+        tuple_printer,       // concept seqan3::tuple_like<>
+        std_byte_printer,    // type std::byte
+        std_variant_printer, // type std::variant<>
+        std_printer          // anything that can be printed by std::ostream
+        >
+{
+public:
+    /*!\brief The function call operator that is only defined if the type is printable.
+     * \tparam stream_t The type of the stream.
+     * \tparam arg_t The type of the argument.
+     * \param[in,out] stream The stream to print to.
+     * \param[in] arg The argument to print.
+     */
+    template <typename stream_t, typename arg_t>
+        requires printable_with<printer_for_t<stream_t &, std::remove_cvref_t<arg_t>>, stream_t &, arg_t>
+    constexpr void operator()(stream_t & stream, arg_t && arg) const
+    {
+        using printer_t = printer_for_t<stream_t &, std::remove_cvref_t<arg_t>>;
+        std::invoke(printer_t{}, stream, std::forward<arg_t>(arg));
+    }
+};
+
+} // namespace seqan3

--- a/include/seqan3/core/debug_stream/optional.hpp
+++ b/include/seqan3/core/debug_stream/optional.hpp
@@ -17,39 +17,45 @@
 
 namespace seqan3
 {
-/*!\name Formatted output overloads
- * \{
- */
-/*!\brief Make std::nullopt_t printable.
- * \tparam    optional_type This is std::nullopt_t.
- * \param[in] s             The seqan3::debug_stream.
- * \param[in] arg           This is std::nullopt.
- * \relates seqan3::debug_stream_type
- */
-template <typename char_t>
-inline debug_stream_type<char_t> & operator<<(debug_stream_type<char_t> & s, std::nullopt_t SEQAN3_DOXYGEN_ONLY(arg))
-{
-    s << "<VALUELESS_OPTIONAL>";
-    return s;
-}
 
-/*!\brief A std::optional can be printed by printing its value or nothing if valueless.
- * \tparam    optional_type The type of the optional.
- * \param[in] s             The seqan3::debug_stream.
- * \param[in] arg           The std::optional.
- * \relates seqan3::debug_stream_type
- */
-template <typename char_t, typename optional_type>
-    requires detail::is_type_specialisation_of_v<std::remove_cvref_t<optional_type>, std::optional>
-inline debug_stream_type<char_t> & operator<<(debug_stream_type<char_t> & s, optional_type && arg)
+//!\brief Printer for formatted output of std::nullopt_t.
+//!\ingroup core_debug_stream
+template <>
+struct optional_printer<std::nullopt_t>
 {
-    if (arg.has_value())
-        s << *arg;
-    else
-        s << "<VALUELESS_OPTIONAL>";
-    return s;
-}
+    /*!\brief Prints `std::nullopt_t` to formatted output stream.
+     * \tparam stream_t The type of the stream to which the value is streamed.
+     * \param[in,out] stream The stream to print to.
+     * \param[in] arg The optional to print.
+     */
+    template <typename stream_t>
+    constexpr void operator()(stream_t & stream, std::nullopt_t const SEQAN3_DOXYGEN_ONLY(arg)) const
+    {
+        stream << "<VALUELESS_OPTIONAL>";
+    }
+};
 
-//!\}
+/*!\brief Printer for formatted output of a std::optional
+ * \tparam T The value type of the std::optional.
+ * \ingroup core_debug_stream
+ */
+template <typename T>
+struct optional_printer<std::optional<T>>
+{
+    /*!\brief Print the optional to the stream by printing its value or nothing if valueless.
+     * \tparam stream_t The type of the stream.
+     * \tparam arg_t The type of the argument.
+     * \param[in,out] stream The stream to print to.
+     * \param[in] arg The optional to print.
+     */
+    template <typename stream_t, typename arg_t>
+    constexpr void operator()(stream_t & stream, arg_t && arg) const
+    {
+        if (arg.has_value())
+            stream << *arg;
+        else
+            stream << "<VALUELESS_OPTIONAL>";
+    }
+};
 
 } // namespace seqan3

--- a/include/seqan3/core/debug_stream/tuple.hpp
+++ b/include/seqan3/core/debug_stream/tuple.hpp
@@ -36,42 +36,34 @@ void print_tuple(debug_stream_type<char_t> & s, tuple_t && t, std::index_sequenc
     s << ')';
 }
 
-/*!\interface seqan3::detail::debug_streamable_tuple <>
- * \brief A helper concept to avoid ambiguous overloads with the debug stream operator for alignments.
- * \ingroup core_debug_stream
- * \tparam tuple_t The tuple type to print to the seqan3::detail::debug_stream_type.
- *
- * \details
- *
- * This concept requires that the given type is a seqan3::tuple_like type but neither a std::ranges::input_range nor
- * an alphabet (see seqan3::alphabet_tuple_base).
- */
-//!\cond
-template <typename tuple_t>
-concept debug_streamable_tuple =
-    !std::ranges::input_range<tuple_t> && !alphabet<tuple_t> && // exclude alphabet_tuple_base
-    tuple_like<std::remove_cvref_t<tuple_t>>;
-//!\endcond
 } // namespace seqan3::detail
 
 namespace seqan3
 {
 
-/*!\brief All tuples can be printed by printing their elements separately.
+/*!\brief Printer for formatted output of tuple like objects.
  * \tparam tuple_t Type of the tuple to be printed; must model seqan3::tuple_like.
- * \param s The seqan3::debug_stream.
- * \param t The tuple.
- * \relates seqan3::debug_stream_type
+ * \ingroup core_debug_stream
  */
-template <typename char_t, typename tuple_t>
-    requires (detail::debug_streamable_tuple<tuple_t>)
-inline debug_stream_type<char_t> & operator<<(debug_stream_type<char_t> & s, tuple_t && t)
+template <tuple_like tuple_t>
+struct tuple_printer<tuple_t>
 {
-    detail::print_tuple(s,
-                        std::forward<tuple_t>(t),
-                        std::make_index_sequence<std::tuple_size_v<std::remove_cvref_t<tuple_t>>>{});
-    return s;
-}
+    /*!\brief Prints a tuple to a formatted output stream.
+     *
+     * Takes a stream and a tuple object as arguments and prints the tuple elements to the stream.
+     * The elements are printed using the `detail::print_tuple` function.
+     *
+     * \tparam stream_t The type of the stream.
+     * \tparam arg_t The type of the argument.
+     * \param[in,out] stream The stream to print to.
+     * \param[in] arg The tuple to print.
+     */
+    template <typename stream_t, typename arg_t>
+    constexpr void operator()(stream_t & stream, arg_t && arg) const
+    {
+        detail::print_tuple(stream, std::forward<arg_t>(arg), std::make_index_sequence<std::tuple_size_v<tuple_t>>{});
+    }
+};
 
 //!\}
 

--- a/include/seqan3/core/debug_stream/variant.hpp
+++ b/include/seqan3/core/debug_stream/variant.hpp
@@ -17,35 +17,34 @@
 
 namespace seqan3
 {
-/*!\name Formatted output overloads
- * \{
- */
+
 /*!\brief A std::variant can be printed by visiting the stream operator for the corresponding type.
- * \tparam    variant_type The type of the variant.
- * \param[in] s            The seqan3::debug_stream.
- * \param[in] v            The variant.
- * \relates seqan3::debug_stream_type
- *
- * \details
- *
- * Note that in case the variant is valueless(_by_exception), nothing is printed.
+ * \tparam variant_ts The types of the variant.
+ * \ingroup core_debug_stream
  */
-template <typename char_t, typename variant_type>
-    requires detail::is_type_specialisation_of_v<std::remove_cvref_t<variant_type>, std::variant>
-inline debug_stream_type<char_t> & operator<<(debug_stream_type<char_t> & s, variant_type && v)
+template <typename... variant_ts>
+struct std_variant_printer<std::variant<variant_ts...>>
 {
-    if (!v.valueless_by_exception())
-        std::visit(
-            [&s](auto && arg)
-            {
-                s << arg;
-            },
-            v);
-    else
-        s << "<VALUELESS_VARIANT>";
-    return s;
-}
-
-//!\}
-
+    /*!\brief Prints the variant by visiting the stream operator for the corresponding type.
+     * \tparam stream_t The type of the stream.
+     * \tparam arg_t The type of the argument.
+     * \param[in,out] stream The output stream.
+     * \param[in] arg The variant argument to print.
+     *
+     * Note that in case the variant is valueless(_by_exception), nothing is printed.
+     */
+    template <typename stream_t, typename arg_t>
+    constexpr void operator()(stream_t & stream, arg_t && arg) const
+    {
+        if (!arg.valueless_by_exception())
+            std::visit(
+                [&stream](auto && elem)
+                {
+                    stream << elem;
+                },
+                arg);
+        else
+            stream << "<VALUELESS_VARIANT>";
+    }
+};
 } // namespace seqan3

--- a/include/seqan3/core/detail/strong_type.hpp
+++ b/include/seqan3/core/detail/strong_type.hpp
@@ -447,34 +447,27 @@ private:
     value_t value;
 };
 
-//------------------------------------------------------------------------------
-// related functions
-//------------------------------------------------------------------------------
-
-/*!\name Formatted output
- * \relates seqan3::detail::strong_type
- * \{
- */
-
-/*!\brief Formatted output to a seqan3::detail::debug_stream_type.
- * \tparam char_t The char type of the seqan3::detail::debug_stream_type.
- * \tparam strong_type_t The strong type to print; must model seqan3::detail::derived_from_strong_type.
- *
- * \param[in,out] stream The output stream.
- * \param[in] value The strong typed value to print.
- *
- * \details
- *
- * Prints the stored value of the given strong type.
- *
- * \returns `stream_t &` A reference to the given stream.
- */
-template <typename char_t, derived_from_strong_type strong_type_t>
-debug_stream_type<char_t> & operator<<(debug_stream_type<char_t> & stream, strong_type_t && value)
-{
-    stream << value.get();
-    return stream;
-}
-//!\}
-
 } // namespace seqan3::detail
+
+namespace seqan3
+{
+/*!\brief A strong type can be printed by printing its underlying value.
+ * \tparam strong_type_t The type of the strong type; must be derived from seqan3::detail::strong_type.
+ * \ingroup core_debug_stream
+ */
+template <detail::derived_from_strong_type strong_type_t>
+struct strong_type_printer<strong_type_t>
+{
+    /*!\brief Prints the stored value of the given strong type.
+     * \tparam stream_t The type of the stream.
+     * \tparam arg_t The type of the argument.
+     * \param[in,out] stream The output stream.
+     * \param[in] arg The strong typed value to print.
+     */
+    template <typename stream_t, typename arg_t>
+    constexpr void operator()(stream_t & stream, arg_t && arg) const
+    {
+        stream << arg.get();
+    }
+};
+} // namespace seqan3

--- a/include/seqan3/io/sam_file/sam_flag.hpp
+++ b/include/seqan3/io/sam_file/sam_flag.hpp
@@ -94,16 +94,22 @@ template <>
 inline constexpr bool add_enum_bitwise_operators<sam_flag> = true;
 //!\endcond
 
-/*!\brief Overload for the seqan3::sam_flags.
- * \tparam char_t Type char type of the debug_stream.
- * \param stream The seqan3::debug_stream.
- * \param flag The flag to print.
- * \relates seqan3::debug_stream_type
+/*!\brief A sam_flag can be printed as an integer value.
+ * \ingroup io_sam_file
  */
-template <typename char_t>
-inline debug_stream_type<char_t> & operator<<(debug_stream_type<char_t> & stream, sam_flag const flag)
+template <>
+struct sam_flag_printer<sam_flag>
 {
-    return stream << static_cast<int16_t>(flag);
-}
+    /*!\brief Prints the sam flag.
+     * \tparam stream_t The output stream type.
+     * \param[in,out] stream The output stream.
+     * \param[in] arg The sam flag to print.
+     */
+    template <typename stream_t>
+    constexpr void operator()(stream_t & stream, sam_flag const arg) const
+    {
+        stream << static_cast<int16_t>(arg);
+    }
+};
 
 } // namespace seqan3

--- a/include/seqan3/io/structure_file/detail.hpp
+++ b/include/seqan3/io/structure_file/detail.hpp
@@ -18,8 +18,7 @@
 
 namespace seqan3::detail
 {
-/*!
- * \brief Transforms a structure annotation string into a base pair probability matrix.
+/*!\brief Transforms a structure annotation string into a base pair probability matrix.
  * \ingroup io_structure_file
  * \throws seqan3::parse_error if unpaired brackets are found in the structure annotation.
  * \tparam structure_alph_type The type of the structure alphabet; must satisfy seqan3::rna_structure_alphabet.

--- a/include/seqan3/search/search_result.hpp
+++ b/include/seqan3/search/search_result.hpp
@@ -181,31 +181,38 @@ public:
     //!\}
 };
 
-/*!\brief Print the seqan3::search_result to seqan3::debug_stream.
- * \tparam char_t The underlying character type of the seqan3::debug_stream_type.
- * \tparam search_result_t A specialization of seqan3::search_result.
- * \param stream The stream.
- * \param result The search result to print.
- * \relates seqan3::debug_stream_type
+/*!\brief The printer used for formatted output of the search result.
+ *
+ * The type of the printer must be a seqan3::search_result type.
+ *
+ * \tparam specs_t The list of types seqan3::search_result is specialised with.
+ * \ingroup search
  */
-template <typename char_t, typename search_result_t>
-    requires detail::is_type_specialisation_of_v<std::remove_cvref_t<search_result_t>, search_result>
-inline debug_stream_type<char_t> & operator<<(debug_stream_type<char_t> & stream, search_result_t && result)
+template <typename... specs_t>
+struct search_result_printer<search_result<specs_t...>>
 {
-    using result_type_list = detail::transfer_template_args_onto_t<std::remove_cvref_t<search_result_t>, type_list>;
+    /*!\brief Prints the search result.
+     * \tparam stream_t The type of the stream.
+     * \tparam arg_t The type of the argument.
+     * \param[in,out] stream The output stream.
+     * \param[in] arg The search result to print.
+     */
+    template <typename stream_t, typename arg_t>
+    constexpr void operator()(stream_t & stream, arg_t && arg) const
+    {
+        using result_type_list = type_list<specs_t...>;
 
-    stream << "<";
-    if constexpr (!std::same_as<list_traits::at<0, result_type_list>, detail::empty_type>)
-        stream << "query_id:" << result.query_id();
-    if constexpr (!std::same_as<list_traits::at<1, result_type_list>, detail::empty_type>)
-        stream << ", index cursor is present";
-    if constexpr (!std::same_as<list_traits::at<2, result_type_list>, detail::empty_type>)
-        stream << ", reference_id:" << result.reference_id();
-    if constexpr (!std::same_as<list_traits::at<3, result_type_list>, detail::empty_type>)
-        stream << ", reference_pos:" << result.reference_begin_position();
-    stream << ">";
-
-    return stream;
-}
+        stream << "<";
+        if constexpr (!std::same_as<list_traits::at<0, result_type_list>, detail::empty_type>)
+            stream << "query_id:" << arg.query_id();
+        if constexpr (!std::same_as<list_traits::at<1, result_type_list>, detail::empty_type>)
+            stream << ", index cursor is present";
+        if constexpr (!std::same_as<list_traits::at<2, result_type_list>, detail::empty_type>)
+            stream << ", reference_id:" << arg.reference_id();
+        if constexpr (!std::same_as<list_traits::at<3, result_type_list>, detail::empty_type>)
+            stream << ", reference_pos:" << arg.reference_begin_position();
+        stream << ">";
+    }
+};
 
 } // namespace seqan3

--- a/include/seqan3/utility/container/dynamic_bitset.hpp
+++ b/include/seqan3/utility/container/dynamic_bitset.hpp
@@ -1925,26 +1925,6 @@ public:
         return is;
     }
 
-    /*!\brief Formatted debug output for the `seqan3::dynamic_bitset`.
-     * \param[in,out] s   The `seqan3::debug_stream` to write to.
-     * \param[in]     arg The `seqan3::dynamic_bitset` to read from.
-     * \returns `s`.
-     *
-     * \details
-     *
-     * Internally calls \ref to_string() "arg.to_string()" and inserts a <code>'</code> at every fourth position.
-     *
-     * \experimentalapi{Experimental since version 3.1.}
-     */
-    template <typename char_t>
-    friend debug_stream_type<char_t> & operator<<(debug_stream_type<char_t> & s, dynamic_bitset arg)
-    {
-        s << (std::string_view{arg.to_string()} | views::interleave(4, std::string_view{"'"})
-              | ranges::to<std::string>());
-        return s;
-    }
-    //!\}
-
     //!\cond DEV
     /*!\brief Serialisation support function.
      * \tparam archive_t Type of `archive`; must satisfy seqan3::cereal_archive.
@@ -1968,6 +1948,27 @@ public:
         data.bits = bits;
     }
     //!\endcond
+};
+
+/*!\brief Prints seqan3::dynamic_bitset.
+ * \ingroup utility_container
+ * \experimentalapi{Experimental since version 3.1.}
+ */
+template <size_t bit_capacity>
+struct dynamic_bitset_printer<dynamic_bitset<bit_capacity>>
+{
+    /*!\brief Prints the dynamic bitset.
+     * \tparam stream_t The type of the stream.
+     * \tparam arg_t The type of the argument.
+     * \param[in,out] stream The output stream.
+     * \param[in] arg The dynamic bitset to print.
+     */
+    template <typename stream_t, typename arg_t>
+    constexpr void operator()(stream_t & stream, arg_t && arg) const
+    {
+        stream << (std::string_view{arg.to_string()} | views::interleave(4, std::string_view{"'"})
+                   | ranges::to<std::string>());
+    }
 };
 
 } // namespace seqan3

--- a/include/seqan3/utility/simd/detail/debug_stream_simd.hpp
+++ b/include/seqan3/utility/simd/detail/debug_stream_simd.hpp
@@ -17,22 +17,30 @@
 namespace seqan3
 {
 
-/*!\brief Overload for debug_stream for simd types.
+/*!\brief Prints simd types.
+ * \tparam simd_t The simd type to print.
  * \ingroup utility_simd
  */
-template <typename char_t, typename simd_t>
-    requires simd::simd_concept<std::remove_cvref_t<simd_t>>
-inline debug_stream_type<char_t> & operator<<(debug_stream_type<char_t> & s, simd_t && simd)
+template <simd::simd_concept simd_t>
+struct simd_printer<simd_t>
 {
-    using simd_type = std::remove_cvref_t<simd_t>;
-    constexpr size_t length = simd::simd_traits<simd_type>::length;
-    using scalar_type = typename simd::simd_traits<simd_type>::scalar_type;
+    /*!\brief Prints the simd value.
+     * \tparam stream_t The type of the stream.
+     * \tparam arg_t The type of the argument.
+     * \param[in,out] stream The output stream.
+     * \param[in] arg The simd type to print.
+     */
+    template <typename stream_t, typename arg_t>
+    constexpr void operator()(stream_t & stream, arg_t && arg) const
+    {
+        constexpr size_t length = simd::simd_traits<simd_t>::length;
+        using scalar_type = typename simd::simd_traits<simd_t>::scalar_type;
 
-    std::array<scalar_type, length> array{};
-    for (size_t i = 0; i < length; ++i)
-        array[i] = simd[i];
-    s << array;
-    return s;
-}
+        std::array<scalar_type, length> array{};
+        for (size_t i = 0; i < length; ++i)
+            array[i] = arg[i];
+        stream << array;
+    }
+};
 
 } // namespace seqan3

--- a/test/unit/alignment/matrix/detail/debug_stream_debug_matrix_test.cpp
+++ b/test/unit/alignment/matrix/detail/debug_stream_debug_matrix_test.cpp
@@ -183,6 +183,7 @@ struct debug_matrix_stream_test : public ::testing::Test
 
 using typename seqan3::detail::debug_matrix_stream_test;
 using debug_stream_test = seqan3::detail::debug_matrix_stream_test;
+using debug_matrix_printer_test = seqan3::detail::debug_matrix_stream_test;
 
 TEST_F(debug_matrix_stream_test, unicode_str_length)
 {
@@ -428,4 +429,27 @@ TEST_F(debug_stream_test, trace_matrix_unicode_with_sequences)
     debug_stream << seqan3::fmtflags2::utf8 << matrix;
 
     EXPECT_EQ(stream.str(), trace_matrix_unicode_with_sequences);
+}
+
+TEST_F(debug_matrix_printer_test, score_matrix_ascii_std_stream)
+{
+    seqan3::detail::debug_matrix matrix{score_matrix};
+    seqan3::alignment_matrix_printer<decltype(matrix)> printer;
+
+    std::stringstream stream;
+    printer(stream, matrix);
+
+    EXPECT_EQ(stream.str(), score_matrix_ascii);
+}
+
+TEST_F(debug_matrix_printer_test, score_matrix_unicode_debug_stream)
+{
+    seqan3::detail::debug_matrix matrix{score_matrix};
+    seqan3::alignment_matrix_printer<decltype(matrix)> printer;
+
+    std::stringstream stream;
+    seqan3::debug_stream_type debug_stream{stream};
+    printer(debug_stream << seqan3::fmtflags2::utf8, matrix);
+
+    EXPECT_EQ(stream.str(), score_matrix_unicode);
 }

--- a/test/unit/alignment/matrix/detail/debug_stream_trace_directions_test.cpp
+++ b/test/unit/alignment/matrix/detail/debug_stream_trace_directions_test.cpp
@@ -40,3 +40,20 @@ TEST(debug_stream_test, unicode)
 
     EXPECT_EQ(s.str(), "↺;↖;↑;←;↖↑;↖←;↑←;↖↑←;⇡;⇠;↖⇡;↖⇡⇠;↖↑⇡←⇠");
 }
+
+TEST(trace_directions_printer_test, std_stream)
+{
+    std::stringstream s{};
+    seqan3::trace_directions_printer<seqan3::detail::trace_directions> printer{};
+    printer(s, N);
+    s << ';';
+    printer(s, D);
+    s << ';';
+    printer(s, L);
+    s << ';';
+    printer(s, U);
+    s << ';';
+    printer(s, D | U | u | L | l);
+
+    EXPECT_EQ(s.str(), "N;D;L;U;DUuLl");
+}

--- a/test/unit/io/record_test.cpp
+++ b/test/unit/io/record_test.cpp
@@ -21,6 +21,7 @@ using default_fields = seqan3::fields<seqan3::field::seq, seqan3::field::id, seq
 // This is needed for EXPECT_RANGE_EQ:
 namespace seqan3
 {
+// TODO: This is only for the test. We might need to consider adding enumeration_names for the io fields to the library.
 template <typename char_t>
 inline debug_stream_type<char_t> & operator<<(debug_stream_type<char_t> & stream, field f)
 {

--- a/test/unit/test/pretty_printing_test.cpp
+++ b/test/unit/test/pretty_printing_test.cpp
@@ -37,6 +37,22 @@ TEST(pretty_printing, char)
     EXPECT_EQ(debug_str('a'), "a"s);
 }
 
+TEST(pretty_printing, charX_t)
+{
+    EXPECT_EQ(gtest_str(char8_t{5}), "U+0005"s);
+    EXPECT_EQ(gtest_str(char16_t{5}), "U+0005"s);
+    EXPECT_EQ(gtest_str(char32_t{5}), "U+0005"s);
+    // EXPECT_EQ(debug_str(char8_t{5}), "U+0005"s);
+    // EXPECT_EQ(debug_str(char16_t{5}), "U+0005"s);
+    // EXPECT_EQ(debug_str(char32_t{5}), "U+0005"s);
+}
+
+TEST(pretty_printing, cstring)
+{
+    EXPECT_EQ(gtest_str("test"), "\"test\""s);
+    EXPECT_EQ(debug_str("test"), "test"s);
+}
+
 TEST(pretty_printing, tuple)
 {
     EXPECT_EQ(gtest_str(std::make_tuple<int, int>(42, -10)), "(42, -10)"s);


### PR DESCRIPTION
This PR builds upon the original proposal of @marehr (#3227).

I changed from the `print` static member function to overloading the function call operator of the printer classes. 
Using this idea, we can now test wether a printer is invocable for a given output stream and the streamable argument.
I also refactored some of the original default_printer code to simplify it.
Among others, the is_printer is not needed anymore as we can use the invocable concept.
For investigating errors I kept the concept `printable_with` which is basically just an alias for the `invocable` concept. 
In addition, I added documentation.
Once this is done, we can look for more debug_stream instances that can be replaced with the printer mechanism.
