### PR TITLE
[FIX] Correctly propagate the constness of the inner range type.

### DIFF
--- a/include/seqan3/utility/simd/views/to_simd.hpp
+++ b/include/seqan3/utility/simd/views/to_simd.hpp
@@ -69,7 +69,7 @@ private:
     /*!\name Auxiliary types
      * \{
      */
-    using inner_range_type = std::ranges::range_value_t<urng_t>;        //!< The inner range type.
+    using inner_range_type = std::ranges::range_reference_t<urng_t>;    //!< The inner range type.
     using chunk_type = std::array<simd_t, simd_traits<simd_t>::length>; //!< The underlying type to hold the chunks.
     using scalar_type = typename simd_traits<simd_t>::scalar_type;      //!< The scalar type.
     //!\brief The SIMD type with maximal number of lanes for the current arch.

--- a/test/unit/utility/simd/views/to_simd_test.cpp
+++ b/test/unit/utility/simd/views/to_simd_test.cpp
@@ -356,3 +356,17 @@ TYPED_TEST(view_to_simd_test, issue_1941)
 
     EXPECT_TRUE((std::common_with<value_t, reference_t>));
 }
+
+TYPED_TEST(view_to_simd_test, const_sequences)
+{
+    using simd_t = typename TestFixture::simd_t;
+
+    auto v = std::as_const(this->sequences) | seqan3::views::to_simd<simd_t>;
+    this->compare(v, this->transformed_simd_vec);
+
+    if constexpr (seqan3::simd::simd_traits<simd_t>::length > 1)
+    {
+        EXPECT_EQ(v.empty(), false);
+        EXPECT_EQ(v.size(), 64u);
+    }
+}


### PR DESCRIPTION
Instead of using the value type of the underlying range we use the reference type, such that in case the original range is passed in as const it is correctly propagated to the inner range type. Otherwise, we might end in the situation that we want to assign a const iterator to a non-const iterator which is not allowed.

<!--
Please see https://github.com/seqan/seqan3/blob/main/CONTRIBUTING.md for a general overview.

Please allow edits from maintainers:
https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests

Once you create the PR, clang-format will be run on the PR, and any formatting changes will be pushed to your fork.
Subsequently, the actual CI will start.

****************************************************************************************************
** Attention: This means that you will have to `git pull` the changes before pushing new commits. **
****************************************************************************************************

Each of your commits will trigger a clang-format commit if there are formatting changes.


While the following guide on rebasing formatting changes is intended for internal use by SeqAn members, and in no way
necessary for contributors, it may still be an interesting read: https://github.com/seqan/seqan3/wiki/Rebasing-clang-format-commits-with-git-absorb
-->
