### PR TITLE
Fixes #3266: Incorrect begin/end of alignment for banded alignment

### DIFF
--- a/include/seqan3/alignment/pairwise/alignment_algorithm.hpp
+++ b/include/seqan3/alignment/pairwise/alignment_algorithm.hpp
@@ -618,8 +618,11 @@ private:
             res.end_positions = alignment_coordinate_t{column_index_type{this->alignment_state.optimum.column_index},
                                                        row_index_type{this->alignment_state.optimum.row_index}};
             // At some point this needs to be refactored so that it is not necessary to adapt the coordinate.
-            if constexpr (traits_t::is_banded)
+            if constexpr (traits_t::is_banded) {
                 res.end_positions.second += res.end_positions.first - this->trace_matrix.band_col_index;
+                res.end_positions.first = this->to_original_sequence1_position(res.end_positions.first);
+                res.end_positions.second = this->to_original_sequence2_position(res.end_positions.second);
+            }
         }
 
         if constexpr (traits_t::compute_begin_positions)
@@ -631,8 +634,10 @@ private:
                 detail::row_index_type{this->alignment_state.optimum.row_index},
                 detail::column_index_type{this->alignment_state.optimum.column_index}};
             auto trace_res = builder(this->trace_matrix.trace_path(optimum_coordinate));
-            res.begin_positions.first = trace_res.first_sequence_slice_positions.first;
-            res.begin_positions.second = trace_res.second_sequence_slice_positions.first;
+            res.begin_positions.first =
+                this->to_original_sequence1_position(trace_res.first_sequence_slice_positions.first);
+            res.begin_positions.second =
+                this->to_original_sequence2_position(trace_res.second_sequence_slice_positions.first);
 
             if constexpr (traits_t::compute_sequence_alignment)
                 res.alignment = std::move(trace_res.alignment);
@@ -697,8 +702,10 @@ private:
 
             if constexpr (traits_t::compute_end_positions)
             {
-                res.end_positions.first = this->alignment_state.optimum.column_index[simd_index];
-                res.end_positions.second = this->alignment_state.optimum.row_index[simd_index];
+                res.end_positions.first =
+                    this->to_original_sequence1_position(this->alignment_state.optimum.column_index[simd_index]);
+                res.end_positions.second =
+                    this->to_original_sequence2_position(this->alignment_state.optimum.row_index[simd_index]);
             }
 
             callback(std::move(res));

--- a/include/seqan3/alignment/pairwise/alignment_algorithm.hpp
+++ b/include/seqan3/alignment/pairwise/alignment_algorithm.hpp
@@ -618,7 +618,8 @@ private:
             res.end_positions = alignment_coordinate_t{column_index_type{this->alignment_state.optimum.column_index},
                                                        row_index_type{this->alignment_state.optimum.row_index}};
             // At some point this needs to be refactored so that it is not necessary to adapt the coordinate.
-            if constexpr (traits_t::is_banded) {
+            if constexpr (traits_t::is_banded)
+            {
                 res.end_positions.second += res.end_positions.first - this->trace_matrix.band_col_index;
                 res.end_positions.first = this->to_original_sequence1_position(res.end_positions.first);
                 res.end_positions.second = this->to_original_sequence2_position(res.end_positions.second);

--- a/include/seqan3/alignment/pairwise/policy/alignment_matrix_policy.hpp
+++ b/include/seqan3/alignment/pairwise/policy/alignment_matrix_policy.hpp
@@ -140,9 +140,8 @@ private:
     * band starts in the origin and ends in the sink.
     */
     template <typename sequence1_t, typename sequence2_t>
-    constexpr auto slice_sequences(sequence1_t & sequence1,
-                                   sequence2_t & sequence2,
-                                   align_cfg::band_fixed_size const & band) noexcept
+    constexpr auto
+    slice_sequences(sequence1_t & sequence1, sequence2_t & sequence2, align_cfg::band_fixed_size const & band) noexcept
     {
         size_t seq1_size = std::ranges::distance(sequence1);
         size_t seq2_size = std::ranges::distance(sequence2);
@@ -200,7 +199,8 @@ private:
      *
      * Only changes the position if the sequence was sliced due to band configuration.
      */
-    constexpr size_t to_original_sequence1_position(size_t position) const noexcept {
+    constexpr size_t to_original_sequence1_position(size_t position) const noexcept
+    {
         return position + seq1_slice_offset;
     }
 
@@ -212,7 +212,8 @@ private:
      *
      * Only changes the position if the sequence was sliced due to band configuration.
      */
-    constexpr size_t to_original_sequence2_position(size_t position) const noexcept {
+    constexpr size_t to_original_sequence2_position(size_t position) const noexcept
+    {
         return position + seq2_slice_offset;
     }
 

--- a/include/seqan3/alignment/pairwise/policy/alignment_matrix_policy.hpp
+++ b/include/seqan3/alignment/pairwise/policy/alignment_matrix_policy.hpp
@@ -191,8 +191,7 @@ private:
         ++trace_matrix_iter;
     }
 
-    /*!
-     * \brief Converts a sliced position in the alignment matrix to the corresponding position in the original sequence 1.
+    /*!\brief Converts a sliced position in the alignment matrix to the corresponding position in the original sequence 1.
      *
      * \param position The position in the sliced alignment matrix.
      * \return The corresponding position in the original sequence 1.
@@ -204,8 +203,7 @@ private:
         return position + seq1_slice_offset;
     }
 
-    /*!
-     * \brief Converts a sliced position in the alignment matrix to the corresponding position in the original sequence 2.
+    /*!\brief Converts a sliced position in the alignment matrix to the corresponding position in the original sequence 2.
      *
      * \param position The position in the sliced alignment matrix.
      * \return The corresponding position in the original sequence 2.

--- a/include/seqan3/alignment/pairwise/policy/alignment_matrix_policy.hpp
+++ b/include/seqan3/alignment/pairwise/policy/alignment_matrix_policy.hpp
@@ -142,23 +142,23 @@ private:
     template <typename sequence1_t, typename sequence2_t>
     constexpr auto slice_sequences(sequence1_t & sequence1,
                                    sequence2_t & sequence2,
-                                   align_cfg::band_fixed_size const & band) const noexcept
+                                   align_cfg::band_fixed_size const & band) noexcept
     {
         size_t seq1_size = std::ranges::distance(sequence1);
         size_t seq2_size = std::ranges::distance(sequence2);
 
         auto trim_sequence1 = [&]() constexpr
         {
-            size_t begin_pos = std::max<std::ptrdiff_t>(band.lower_diagonal - 1, 0);
+            seq1_slice_offset = std::max<std::ptrdiff_t>(band.lower_diagonal - 1, 0);
             size_t end_pos = std::min<std::ptrdiff_t>(band.upper_diagonal + seq2_size, seq1_size);
-            return sequence1 | views::slice(begin_pos, end_pos);
+            return sequence1 | views::slice(seq1_slice_offset, end_pos);
         };
 
         auto trim_sequence2 = [&]() constexpr
         {
-            size_t begin_pos = std::abs(std::min<std::ptrdiff_t>(band.upper_diagonal + 1, 0));
+            seq2_slice_offset = std::abs(std::min<std::ptrdiff_t>(band.upper_diagonal + 1, 0));
             size_t end_pos = std::min<std::ptrdiff_t>(seq1_size - band.lower_diagonal, seq2_size);
-            return sequence2 | views::slice(begin_pos, end_pos);
+            return sequence2 | views::slice(seq2_slice_offset, end_pos);
         };
 
         return std::tuple{trim_sequence1(), trim_sequence2()};
@@ -192,10 +192,37 @@ private:
         ++trace_matrix_iter;
     }
 
+    /*!
+     * \brief Converts a sliced position in the alignment matrix to the corresponding position in the original sequence 1.
+     *
+     * \param position The position in the sliced alignment matrix.
+     * \return The corresponding position in the original sequence 1.
+     *
+     * Only changes the position if the sequence was sliced due to band configuration.
+     */
+    constexpr size_t to_original_sequence1_position(size_t position) const noexcept {
+        return position + seq1_slice_offset;
+    }
+
+    /*!
+     * \brief Converts a sliced position in the alignment matrix to the corresponding position in the original sequence 2.
+     *
+     * \param position The position in the sliced alignment matrix.
+     * \return The corresponding position in the original sequence 2.
+     *
+     * Only changes the position if the sequence was sliced due to band configuration.
+     */
+    constexpr size_t to_original_sequence2_position(size_t position) const noexcept {
+        return position + seq2_slice_offset;
+    }
+
     score_matrix_t score_matrix{}; //!< The scoring matrix.
     trace_matrix_t trace_matrix{}; //!< The trace matrix if needed.
 
     typename score_matrix_t::iterator score_matrix_iter{}; //!< The matrix iterator over the score matrix.
     typename trace_matrix_t::iterator trace_matrix_iter{}; //!< The matrix iterator over the trace matrix.
+
+    size_t seq1_slice_offset{}; //!< The offset of the first sequence slice.
+    size_t seq2_slice_offset{}; //!< The offset of the second sequence slice;
 };
 } // namespace seqan3::detail

--- a/test/unit/alignment/pairwise/global_affine_banded_test.cpp
+++ b/test/unit/alignment/pairwise/global_affine_banded_test.cpp
@@ -5,7 +5,6 @@
 #include <gtest/gtest.h>
 
 #include <seqan3/alignment/pairwise/align_pairwise.hpp>
-
 #include <seqan3/core/debug_stream.hpp>
 
 #include "fixture/global_affine_banded.hpp"
@@ -76,22 +75,20 @@ TEST(banded_alignment_issue3266_test, wrong_begin_and_end_position)
     using namespace seqan3;
     using namespace seqan3::literals;
 
-    const auto configGeneral =
-        align_cfg::scoring_scheme{nucleotide_scoring_scheme{match_score{1}, mismatch_score{-1}}} |
-        align_cfg::gap_cost_affine{align_cfg::open_score{0}, align_cfg::extension_score{-1}} |
-         align_cfg::method_global{
-            align_cfg::free_end_gaps_sequence1_leading{true},
-            align_cfg::free_end_gaps_sequence2_leading{true},
-            align_cfg::free_end_gaps_sequence1_trailing{true},
-            align_cfg::free_end_gaps_sequence2_trailing{true}};
+    auto const configGeneral = align_cfg::scoring_scheme{nucleotide_scoring_scheme{match_score{1}, mismatch_score{-1}}}
+                             | align_cfg::gap_cost_affine{align_cfg::open_score{0}, align_cfg::extension_score{-1}}
+                             | align_cfg::method_global{align_cfg::free_end_gaps_sequence1_leading{true},
+                                                        align_cfg::free_end_gaps_sequence2_leading{true},
+                                                        align_cfg::free_end_gaps_sequence1_trailing{true},
+                                                        align_cfg::free_end_gaps_sequence2_trailing{true}};
 
-    const auto configBanded = configGeneral | align_cfg::band_fixed_size{align_cfg::lower_diagonal{-40},
-                                                                         align_cfg::upper_diagonal{-20}};
+    auto const configBanded =
+        configGeneral | align_cfg::band_fixed_size{align_cfg::lower_diagonal{-40}, align_cfg::upper_diagonal{-20}};
 
-                              //0         1         2         3         4
-                              //01234567890123456789012345678901234567890
+    //0         1         2         3         4
+    //01234567890123456789012345678901234567890
     std::pair p{"CGTCTA"_dna4, "AAACCCGGGTTTAAACCCGGGTTTCGTGTACCCCCCCCCCC"_dna4};
-                                //                      CGTCTA
+    //                      CGTCTA
 
     auto general_results = align_pairwise(p, configGeneral);
     auto general_res = *std::ranges::begin(general_results);

--- a/test/unit/alignment/pairwise/global_affine_banded_test.cpp
+++ b/test/unit/alignment/pairwise/global_affine_banded_test.cpp
@@ -5,7 +5,6 @@
 #include <gtest/gtest.h>
 
 #include <seqan3/alignment/pairwise/align_pairwise.hpp>
-#include <seqan3/core/debug_stream.hpp>
 
 #include "fixture/global_affine_banded.hpp"
 #include "pairwise_alignment_single_test_template.hpp"


### PR DESCRIPTION
In case the sequences are sliced by cutting off a prefix of the original seuence due to the band configuration, the relative positions of the sliced sequences was reported inside of the alignment result.
However, this slicing happens only internally and thus the positions reported should correspond to the ones of the original sequences.
We fix this by tracking the offset of the prefix that was cut off and add this to the relative positions during result creation to get the absolute positions.

<!--
Please see https://github.com/seqan/seqan3/blob/main/CONTRIBUTING.md for a general overview.

Please allow edits from maintainers:
https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests

Once you create the PR, clang-format will be run on the PR, and any formatting changes will be pushed to your fork.
Subsequently, the actual CI will start.

****************************************************************************************************
** Attention: This means that you will have to `git pull` the changes before pushing new commits. **
****************************************************************************************************

Each of your commits will trigger a clang-format commit if there are formatting changes.


While the following guide on rebasing formatting changes is intended for internal use by SeqAn members, and in no way
necessary for contributors, it may still be an interesting read: https://github.com/seqan/seqan3/wiki/Rebasing-clang-format-commits-with-git-absorb
-->
