### PR TITLE
[FIX] Codecov

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -4,7 +4,7 @@
 
 # See https://docs.codecov.io/docs/codecovyml-reference
 codecov:
-  token: a75b1e95-134c-4ada-adac-5846045f188
+  token: a75b1e95-134c-4ada-adac-5846045f188e
   require_ci_to_pass: no  # codecov reports its results independent of whether CI passed
   notify:
     wait_for_ci: no       # codecov has not to wait until the CI is finished to post its results


### PR DESCRIPTION
* Missing character in codecov.yaml
* ~~Looks like we need one successful deployment such that the new yml is used, hence re-adding the secret~~