### PR TITLE
[FIX] gcc-15: Better bogus memcpy fix

### DIFF
--- a/include/seqan3/alignment/matrix/detail/score_matrix_single_column.hpp
+++ b/include/seqan3/alignment/matrix/detail/score_matrix_single_column.hpp
@@ -113,7 +113,14 @@ public:
         this->number_of_columns = number_of_columns.get();
         optimal_column.clear();
         horizontal_column.clear();
+#if SEQAN3_WORKAROUND_GCC_BOGUS_MEMCPY
+#    pragma GCC diagnostic push
+#    pragma GCC diagnostic ignored "-Wstringop-overflow"
+#endif // SEQAN3_WORKAROUND_GCC_BOGUS_MEMCPY
         optimal_column.resize(number_of_rows.get(), initial_value);
+#if SEQAN3_WORKAROUND_GCC_BOGUS_MEMCPY
+#    pragma GCC diagnostic pop
+#endif // SEQAN3_WORKAROUND_GCC_BOGUS_MEMCPY
         horizontal_column.resize(number_of_rows.get(), initial_value);
         vertical_column = views::repeat_n(initial_value, number_of_rows.get());
     }

--- a/include/seqan3/alignment/pairwise/detail/pairwise_alignment_algorithm_banded.hpp
+++ b/include/seqan3/alignment/pairwise/detail/pairwise_alignment_algorithm_banded.hpp
@@ -133,15 +133,8 @@ public:
         size_t const sequence1_size = std::ranges::distance(simd_seq1_collection);
         size_t const sequence2_size = std::ranges::distance(simd_seq2_collection);
 
-#if SEQAN3_WORKAROUND_GCC_BOGUS_MEMCPY
-#    pragma GCC diagnostic push
-#    pragma GCC diagnostic ignored "-Wstringop-overflow"
-#endif // SEQAN3_WORKAROUND_GCC_BOGUS_MEMCPY
         auto && [alignment_matrix, index_matrix] =
             this->acquire_matrices(sequence1_size, sequence2_size, this->lowest_viable_score());
-#if SEQAN3_WORKAROUND_GCC_BOGUS_MEMCPY
-#    pragma GCC diagnostic pop
-#endif // SEQAN3_WORKAROUND_GCC_BOGUS_MEMCPY
 
         compute_matrix(simd_seq1_collection, simd_seq2_collection, alignment_matrix, index_matrix);
 


### PR DESCRIPTION
~~This partially reverts https://github.com/seqan/seqan3/commit/33f3eba4ffb7aaabf77f11af767a3ef840bba2ba~~

~~It fixes a new bogus memcpy error with gcc-15 (fedora build).
But this one had a better stacktrace and also happens to fix the one from the linked commit.~~

~~From what I can tell, the compiler is confused by the `optimal_column.clear()` (but not `horizontal_column.clear()`). Seems like, for the diagnostic, it forgets that it was cleared and then weird stuff happens in `resize()` - only affects diagnostics, not the actual compiled code.~~

