### PR TITLE
Adds missing char8_t type to list of viable char types for which char adaption works.

### DIFF
--- a/include/seqan3/alphabet/adaptation/char.hpp
+++ b/include/seqan3/alphabet/adaptation/char.hpp
@@ -31,9 +31,9 @@ namespace seqan3::detail
 //!\ingroup alphabet_adaptation
 //!\hideinitializer
 template <typename type>
-constexpr bool is_char_adaptation_v = std::same_as<type, char> || std::same_as<type, char8_t> ||
-                                      std::same_as<type, char16_t> || std::same_as<type, char32_t> ||
-                                      std::same_as<type, wchar_t>;
+constexpr bool is_char_adaptation_v =
+    std::same_as<type, char> || std::same_as<type, char8_t> || std::same_as<type, char16_t>
+    || std::same_as<type, char32_t> || std::same_as<type, wchar_t>;
 } // namespace seqan3::detail
 
 namespace seqan3::custom

--- a/include/seqan3/alphabet/adaptation/char.hpp
+++ b/include/seqan3/alphabet/adaptation/char.hpp
@@ -31,8 +31,9 @@ namespace seqan3::detail
 //!\ingroup alphabet_adaptation
 //!\hideinitializer
 template <typename type>
-constexpr bool is_char_adaptation_v = std::same_as<type, char> || std::same_as<type, char16_t>
-                                   || std::same_as<type, char32_t> || std::same_as<type, wchar_t>;
+constexpr bool is_char_adaptation_v = std::same_as<type, char> || std::same_as<type, char8_t> ||
+                                      std::same_as<type, char16_t> || std::same_as<type, char32_t> ||
+                                      std::same_as<type, wchar_t>;
 } // namespace seqan3::detail
 
 namespace seqan3::custom


### PR DESCRIPTION
<!--
Please see https://github.com/seqan/seqan3/blob/main/CONTRIBUTING.md for a general overview.

Please allow edits from maintainers:
https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests

Once you create the PR, clang-format will be run on the PR, and any formatting changes will be pushed to your fork.
Subsequently, the actual CI will start.

****************************************************************************************************
** Attention: This means that you will have to `git pull` the changes before pushing new commits. **
****************************************************************************************************

Each of your commits will trigger a clang-format commit if there are formatting changes.


While the following guide on rebasing formatting changes is intended for internal use by SeqAn members, and in no way
necessary for contributors, it may still be an interesting read: https://github.com/seqan/seqan3/wiki/Rebasing-clang-format-commits-with-git-absorb
-->
