### PR TITLE
[INFRA] Remove GIT_TAG for URL download

### DIFF
--- a/cmake/package-lock.cmake
+++ b/cmake/package-lock.cmake
@@ -18,7 +18,6 @@ CPMDeclarePackage (cereal
 set (SEQAN3_SDSL_VERSION 14cd017027ea742353fc5b500d1cb1d95896b77e)
 CPMDeclarePackage (sdsl-lite
                    NAME sdsl-lite
-                   GIT_TAG ${SEQAN3_SDSL_VERSION}
                    URL https://github.com/xxsds/sdsl-lite/archive/${SEQAN3_SDSL_VERSION}.tar.gz
                    DOWNLOAD_ONLY YES
                    QUIET YES)


### PR DESCRIPTION
The GIT_TAG is ignored, but it causes CPM to expect a git repository. When using CPM_SOURCE_CACHE, this leads to a warning, because CPM wants to run `git status` in the cached directory.

<!--
Please see https://github.com/seqan/seqan3/blob/main/CONTRIBUTING.md for a general overview.

Please allow edits from maintainers:
https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests

Once you create the PR, clang-format will be run on the PR, and any formatting changes will be pushed to your fork.
Subsequently, the actual CI will start.

****************************************************************************************************
** Attention: This means that you will have to `git pull` the changes before pushing new commits. **
****************************************************************************************************

Each of your commits will trigger a clang-format commit if there are formatting changes.


While the following guide on rebasing formatting changes is intended for internal use by SeqAn members, and in no way
necessary for contributors, it may still be an interesting read: https://github.com/seqan/seqan3/wiki/Rebasing-clang-format-commits-with-git-absorb
-->
