### PR TITLE
[FIX] ciso646 is deprecated

### DIFF
--- a/include/seqan3/core/platform.hpp
+++ b/include/seqan3/core/platform.hpp
@@ -9,9 +9,7 @@
 
 #pragma once
 
-#include <cinttypes>
-#include <ciso646> // makes _LIBCPP_VERSION available
-#include <cstddef> // makes __GLIBCXX__ available
+#include <version>
 
 // macro cruft
 //!\cond
@@ -103,10 +101,6 @@
 // ============================================================================
 //  C++ standard and features
 // ============================================================================
-
-#if __has_include(<version>)
-#    include <version>
-#endif
 
 // C++ standard [required]
 #ifdef __cplusplus


### PR DESCRIPTION
https://github.com/gcc-mirror/gcc/commit/5c34f02ba7ebe0dfec5595ebc8298c47d5f65e6e#diff-62a23e8a5ebebf0690390ca9d369d4a79f6e85ffc00712f521ebcd0206a62dbc

```cpp
#if __cplusplus >= 202002L && ! _GLIBCXX_USE_DEPRECATED
#  error "<ciso646> is not a standard header in C++20, use <version> to detect implementation-specific macros"
#elif __cplusplus >= 201703L && defined __DEPRECATED
#  pragma GCC diagnostic push
#  pragma GCC diagnostic ignored "-Wc++23-extensions"
#  warning "<ciso646> is deprecated in C++17, use <version> to detect implementation-specific macros"
#  pragma GCC diagnostic pop
#endif
```

Errors on nightly gcc trunk builds

`<version>` makes both `__GLIBCXX__` and `_LIBCPP_VERSION` available