### PR TITLE
[TEST] Skip parallel tests on machines having a single CPU

### DIFF
--- a/test/unit/contrib/parallel/buffer_queue_parallel_test.cpp
+++ b/test/unit/contrib/parallel/buffer_queue_parallel_test.cpp
@@ -15,11 +15,8 @@
 template <typename sequential_push_t, typename sequential_pop_t>
 void test_buffer_queue_wait_status()
 {
-    size_t thread_count = std::thread::hardware_concurrency();
-
-    // limit thread count as virtualbox (used by Travis) seems to have problems with thread congestion
-    if (thread_count > 4)
-        thread_count = 4;
+    // At least two threads (one producer and one consumer), at most 4 threads (avoid congestion).
+    size_t thread_count = std::clamp<size_t>(std::thread::hardware_concurrency(), 2u, 4u);
 
     size_t writer_count = thread_count / 2;
     if constexpr (sequential_push_t::value)
@@ -129,11 +126,9 @@ void test_buffer_queue_wait_throw(size_t initialCapacity)
     }
 
     volatile std::atomic<size_t> chk_sum2 = 0;
-    size_t thread_count = std::thread::hardware_concurrency();
 
-    // limit thread count as virtualbox (used by Travis) seems to have problems with thread congestion
-    if (thread_count > 4)
-        thread_count = 4;
+    // At least two threads (one producer and one consumer), at most 4 threads (avoid congestion).
+    size_t thread_count = std::clamp<size_t>(std::thread::hardware_concurrency(), 2u, 4u);
 
     size_t writer_count = thread_count / 2;
     if constexpr (sequential_push_t::value)


### PR DESCRIPTION
Otherwise this is what happens:

```
The following tests FAILED:
        5762 - contrib/parallel/buffer_queue_parallel_test::buffer_queue.spmc_sum (Failed)
        5763 - contrib/parallel/buffer_queue_parallel_test::buffer_queue.mpsc_sum (Failed)
        5764 - contrib/parallel/buffer_queue_parallel_test::buffer_queue.mpmc_sum (Failed)
        5767 - contrib/parallel/buffer_queue_parallel_test::buffer_queue.spmc_dynamicsize (Failed)
        5768 - contrib/parallel/buffer_queue_parallel_test::buffer_queue.spmc_fixedsize (Failed)
        5769 - contrib/parallel/buffer_queue_parallel_test::buffer_queue.mpsc_dynamicsize (Failed)
        5770 - contrib/parallel/buffer_queue_parallel_test::buffer_queue.mpsc_fixedsize (Failed)
        5771 - contrib/parallel/buffer_queue_parallel_test::buffer_queue.mpmc_dynamicsize (Failed)
        5772 - contrib/parallel/buffer_queue_parallel_test::buffer_queue.mpmc_fixedsize (Failed)
Errors while running CTest
```
