### PR TITLE
[FIX] cpp26: std::is_trivial_v is deprecated

### DIFF
--- a/include/seqan3/utility/concept.hpp
+++ b/include/seqan3/utility/concept.hpp
@@ -134,7 +134,7 @@ concept trivially_copyable = std::copyable<t> && std::is_trivially_copyable_v<t>
  */
 //!\cond
 template <typename t>
-concept trivial = trivially_copyable<t> && trivially_destructible<t> && std::is_trivial_v<t>;
+concept trivial = trivially_copyable<t> && trivially_destructible<t> && std::is_trivially_default_constructible_v<t>;
 //!\endcond
 
 /*!\interface seqan3::standard_layout

--- a/include/seqan3/utility/tuple/pod_tuple.hpp
+++ b/include/seqan3/utility/tuple/pod_tuple.hpp
@@ -12,6 +12,7 @@
 #include <tuple>
 #include <type_traits>
 
+#include <seqan3/utility/concept.hpp>
 #include <seqan3/utility/type_pack/traits.hpp>
 
 namespace seqan3
@@ -46,7 +47,7 @@ struct pod_tuple
 template <typename type0, typename... types>
 struct pod_tuple<type0, types...>
 {
-    static_assert(std::is_standard_layout_v<type0> && std::is_trivial_v<type0>, SEQAN_NOT_POD);
+    static_assert(std::is_standard_layout_v<type0> && seqan3::trivial<type0>, SEQAN_NOT_POD);
     //!\cond DEV
     //!\brief The first element as member.
     type0 _head;
@@ -114,7 +115,7 @@ struct pod_tuple<type0, types...>
 template <typename type0>
 struct pod_tuple<type0>
 {
-    static_assert(std::is_standard_layout_v<type0> && std::is_trivial_v<type0>, SEQAN_NOT_POD);
+    static_assert(std::is_standard_layout_v<type0> && seqan3::trivial<type0>, SEQAN_NOT_POD);
     //!\cond DEV
     //!\brief The first element as member.
     type0 _head;

--- a/test/snippet/utility/tuple/pod_tuple.cpp
+++ b/test/snippet/utility/tuple/pod_tuple.cpp
@@ -9,7 +9,7 @@ int main()
 {
     seqan3::pod_tuple<int, float> tuple1{3, 4.7};
     static_assert(std::is_standard_layout_v<seqan3::pod_tuple<int, float>>);
-    static_assert(std::is_trivial_v<seqan3::pod_tuple<int, float>>);
+    static_assert(seqan3::trivial<seqan3::pod_tuple<int, float>>);
     seqan3::debug_stream << std::get<int>(tuple1) << '\n'; // 3
 
     // template parameters are automatically deduced:

--- a/test/unit/alphabet/adaptation/char_test.cpp
+++ b/test/unit/alphabet/adaptation/char_test.cpp
@@ -29,7 +29,7 @@ TYPED_TEST(char_adaptation, type_properties)
 {
     EXPECT_TRUE((std::is_trivially_copyable_v<TypeParam>));
     EXPECT_TRUE((std::is_trivially_default_constructible_v<TypeParam>));
-    EXPECT_TRUE((std::is_trivial_v<TypeParam>));
+    EXPECT_TRUE((seqan3::trivial<TypeParam>));
 }
 
 TYPED_TEST(char_adaptation, alphabet_char_t)

--- a/test/unit/alphabet/adaptation/uint_test.cpp
+++ b/test/unit/alphabet/adaptation/uint_test.cpp
@@ -32,7 +32,7 @@ TYPED_TEST(uint_adaptation, type_properties)
 {
     EXPECT_TRUE((std::is_trivially_copyable_v<TypeParam>));
     EXPECT_TRUE((std::is_trivially_default_constructible_v<TypeParam>));
-    EXPECT_TRUE((std::is_trivial_v<TypeParam>));
+    EXPECT_TRUE((seqan3::trivial<TypeParam>));
 }
 
 TYPED_TEST(uint_adaptation, alphabet_rank_t)

--- a/test/unit/alphabet/aminoacid/aminoacid_test_template.hpp
+++ b/test/unit/alphabet/aminoacid/aminoacid_test_template.hpp
@@ -17,7 +17,7 @@ TYPED_TEST_SUITE_P(aminoacid);
 
 TYPED_TEST_P(aminoacid, concept_check)
 {
-    EXPECT_TRUE(std::is_trivial_v<TypeParam>);
+    EXPECT_TRUE(seqan3::trivial<TypeParam>);
 
     EXPECT_TRUE(seqan3::aminoacid_alphabet<TypeParam>);
     EXPECT_TRUE(seqan3::aminoacid_alphabet<TypeParam &>);

--- a/test/unit/alphabet/nucleotide/nucleotide_test_template.hpp
+++ b/test/unit/alphabet/nucleotide/nucleotide_test_template.hpp
@@ -16,7 +16,7 @@ TYPED_TEST_SUITE_P(nucleotide);
 
 TYPED_TEST_P(nucleotide, concept_check)
 {
-    EXPECT_TRUE(std::is_trivial_v<TypeParam>);
+    EXPECT_TRUE(seqan3::trivial<TypeParam>);
 
     EXPECT_TRUE(seqan3::nucleotide_alphabet<TypeParam>);
     EXPECT_TRUE(seqan3::nucleotide_alphabet<TypeParam &>);

--- a/test/unit/alphabet/quality/phred_test_template.hpp
+++ b/test/unit/alphabet/quality/phred_test_template.hpp
@@ -14,7 +14,7 @@ TYPED_TEST_SUITE_P(phred);
 // test provision of data type `phred_type` and phred converter.
 TYPED_TEST_P(phred, concept_check)
 {
-    EXPECT_TRUE(std::is_trivial_v<TypeParam>);
+    EXPECT_TRUE(seqan3::trivial<TypeParam>);
 
     EXPECT_TRUE(seqan3::quality_alphabet<TypeParam>);
     EXPECT_TRUE(seqan3::quality_alphabet<TypeParam &>);

--- a/test/unit/utility/tuple/pod_tuple_test.cpp
+++ b/test/unit/utility/tuple/pod_tuple_test.cpp
@@ -6,7 +6,6 @@
 
 #include <type_traits>
 
-#include <seqan3/utility/concept.hpp>
 #include <seqan3/utility/tuple/pod_tuple.hpp>
 
 using tuple_t = seqan3::pod_tuple<int, long, float>;


### PR DESCRIPTION
use 'is_trivially_default_constructible_v && is_trivially_copyable_v' instead

<!--
Please see https://github.com/seqan/seqan3/blob/main/CONTRIBUTING.md for a general overview.

Please allow edits from maintainers:
https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests

Once you create the PR, clang-format will be run on the PR, and any formatting changes will be pushed to your fork.
Subsequently, the actual CI will start.

****************************************************************************************************
** Attention: This means that you will have to `git pull` the changes before pushing new commits. **
****************************************************************************************************

Each of your commits will trigger a clang-format commit if there are formatting changes.


While the following guide on rebasing formatting changes is intended for internal use by SeqAn members, and in no way
necessary for contributors, it may still be an interesting read: https://github.com/seqan/seqan3/wiki/Rebasing-clang-format-commits-with-git-absorb
-->
