### PR TITLE
[INFRA] Debian cron

### DIFF
--- a/.github/workflows/cron_debian.yml
+++ b/.github/workflows/cron_debian.yml
@@ -1,0 +1,72 @@
+# SPDX-FileCopyrightText: 2006-2025 Knut Reinert & Freie Universität Berlin
+# SPDX-FileCopyrightText: 2016-2025 Knut Reinert & MPI für molekulare Genetik
+# SPDX-License-Identifier: CC0-1.0
+
+name: Debian
+
+on:
+  schedule:
+    - cron: "0 1 * * THU"
+  workflow_dispatch:
+
+concurrency:
+  group: debian-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  TZ: Europe/Berlin
+
+defaults:
+  run:
+    shell: bash -Eeuxo pipefail {0}
+
+jobs:
+  build:
+    name: Debian
+    runs-on: ubuntu-latest
+    if: github.repository_owner == 'seqan' || github.event_name == 'workflow_dispatch'
+    container:
+      image: debian:unstable
+    steps:
+      - name: Install Essentials
+        run: |
+          apt-get update
+          apt-get install --yes --no-install-recommends build-essential git cmake wget fakeroot ca-certificates
+
+      - name: Setup Repo
+        run: |
+          mkdir unstable && cd unstable
+          git clone --depth 1 https://github.com/seqan/seqan3.git
+          cd seqan3/
+          git remote add salsa https://salsa.debian.org/med-team/seqan3.git
+          git fetch --depth 1 salsa
+          git checkout salsa/debian/experimental -- debian
+
+      - name: Reduce Noise
+        working-directory: unstable/seqan3
+        run: |
+          if [[ -f test/cmake/seqan3_require_ccache.cmake ]]; then
+            echo "" > test/cmake/seqan3_require_ccache.cmake
+          fi
+          if [[ -f test/documentation/seqan3_doxygen_cfg.in ]]; then
+            sed -i 's@^\(QUIET\s*=\) NO@\1 YES@' test/documentation/seqan3_doxygen_cfg.in
+          fi
+
+      - name: Install Dependencies
+        working-directory: unstable/seqan3
+        run: apt-get build-dep --yes --no-install-recommends .
+
+      - name: Build
+        working-directory: unstable/seqan3
+        run: dpkg-buildpackage --unsigned-changes --unsigned-source --build=binary
+
+      - name: Upload Artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: debian-seqan3-artifacts
+          path: |
+            unstable/**/seqan3*.deb
+            unstable/**/libseqan3*.deb
+            unstable/**/seqan3*.changes
+            unstable/**/seqan3*.buildinfo


### PR DESCRIPTION
This builds the Debian package on the main branch.

It's basically an API-Stability check for our package builds.

Errors either mean that something was overlooked when changing code or that the Debian package would need patches. In the latter case, it's nice to see that before an RC is released because there are way fewer commits between cron runs than between a stable release and the first release candidate of the next version.