### PR TITLE
[FIX] std::is_trivial is deprecated (sdsl)

### DIFF
--- a/include/seqan3/contrib/sdsl-lite.hpp
+++ b/include/seqan3/contrib/sdsl-lite.hpp
@@ -10,6 +10,7 @@
 // * All comments were removed.
 // * "SDSL_" was replaced with "SDSL3_". This affects macros and include guards.
 // * The namespace was changed from "sdsl" to "seqan3::contrib::sdsl".
+// * "std::is_trivial" was replaced with "is_trivially_default_constructible && is_trivially_copyable".
 
 #pragma once
 
@@ -3170,7 +3171,7 @@ serialize(X const & x, std::ostream & out, structure_tree_node * v = nullptr, st
     return x.serialize(out, v, name);
 }
 template <typename X>
-typename std::enable_if<std::is_standard_layout<X>::value && std::is_trivial<X>::value, uint64_t>::type
+typename std::enable_if<std::is_standard_layout<X>::value && std::is_trivially_default_constructible<X>::value && std::is_trivially_copyable<X>::value, uint64_t>::type
 serialize(X const & x, std::ostream & out, structure_tree_node * v = nullptr, std::string name = "")
 {
     return write_member(x, out, v, name);
@@ -3187,7 +3188,7 @@ typename std::enable_if<has_load<X>::value, void>::type load(X & x, std::istream
     x.load(in);
 }
 template <typename X>
-typename std::enable_if<std::is_standard_layout<X>::value && std::is_trivial<X>::value, void>::type
+typename std::enable_if<std::is_standard_layout<X>::value && std::is_trivially_default_constructible<X>::value && std::is_trivially_copyable<X>::value, void>::type
 load(X & x, std::istream & in)
 {
     read_member(x, in);

--- a/test/scripts/amalgamate-sdsl.sh
+++ b/test/scripts/amalgamate-sdsl.sh
@@ -50,6 +50,10 @@ CONTENT=${CONTENT//SDSL_/SDSL3_}
 CONTENT=${CONTENT//namespace sdsl/namespace seqan3::contrib::sdsl}
 CONTENT=${CONTENT//sdsl::/seqan3::contrib::sdsl::}
 
+## Patches
+# [C++26] `std::is_trivial` is deprecated: use `is_trivially_default_constructible && is_trivially_copyable` instead
+CONTENT=${CONTENT//std::is_trivial<X>::value/std::is_trivially_default_constructible<X>::value \&\& std::is_trivially_copyable<X>::value}
+
 cat <<EOL > sdsl-lite.hpp
 // SPDX-FileCopyrightText: 2016 SDSL Project Authors
 // SPDX-License-Identifier: BSD-3-Clause
@@ -63,6 +67,7 @@ cat <<EOL > sdsl-lite.hpp
 // * All comments were removed.
 // * "SDSL_" was replaced with "SDSL3_". This affects macros and include guards.
 // * The namespace was changed from "sdsl" to "seqan3::contrib::sdsl".
+// * "std::is_trivial" was replaced with "is_trivially_default_constructible && is_trivially_copyable".
 
 #pragma once
 


### PR DESCRIPTION
It's not included via `-isystem` anymore, so we see the deprecation warning.

Note that we could add a `#pragma GCC system_header` to mark it as system header.
This is also accepted by Clang.