### PR TITLE
[FIX] Do not find_package yourself

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@ project (seqan3
          DESCRIPTION "SeqAn3 -- the modern C++ library for sequence analysis"
          HOMEPAGE_URL "https://github.com/seqan/seqan3")
 
-find_package (SeqAn3 3.0 REQUIRED HINTS ${SEQAN3_MODULE_PATH})
+include (seqan3-config)
 
 option (INSTALL_SEQAN3 "Enable installation of seqan3. (Projects embedding seqan3 may want to turn this OFF.)" ON)
 

--- a/cmake/seqan3-config.cmake
+++ b/cmake/seqan3-config.cmake
@@ -281,24 +281,28 @@ endif ()
 # Finish find_package call
 # ----------------------------------------------------------------------------
 
-find_package_handle_standard_args (${CMAKE_FIND_PACKAGE_NAME} REQUIRED_VARS SEQAN3_INCLUDE_DIR)
+if (CMAKE_FIND_PACKAGE_NAME)
+    find_package_handle_standard_args (${CMAKE_FIND_PACKAGE_NAME} REQUIRED_VARS SEQAN3_INCLUDE_DIR)
 
-# Set SEQAN3_* variables with the content of ${CMAKE_FIND_PACKAGE_NAME}_(FOUND|...|VERSION)
-# This needs to be done, because `find_package(SeqAn3)` might be called in any case-sensitive way and we want to
-# guarantee that SEQAN3_* are always set.
-foreach (package_var
-         FOUND
-         DIR
-         ROOT
-         CONFIG
-         VERSION
-         VERSION_MAJOR
-         VERSION_MINOR
-         VERSION_PATCH
-         VERSION_TWEAK
-         VERSION_COUNT)
-    set (SEQAN3_${package_var} "${${CMAKE_FIND_PACKAGE_NAME}_${package_var}}")
-endforeach ()
+    # Set SEQAN3_* variables with the content of ${CMAKE_FIND_PACKAGE_NAME}_(FOUND|...|VERSION)
+    # This needs to be done, because `find_package(SeqAn3)` might be called in any case-sensitive way and we want to
+    # guarantee that SEQAN3_* are always set.
+    foreach (package_var
+             FOUND
+             DIR
+             ROOT
+             CONFIG
+             VERSION
+             VERSION_MAJOR
+             VERSION_MINOR
+             VERSION_PATCH
+             VERSION_TWEAK
+             VERSION_COUNT)
+        set (SEQAN3_${package_var} "${${CMAKE_FIND_PACKAGE_NAME}_${package_var}}")
+    endforeach ()
+else ()
+    set (SEQAN3_VERSION "${PACKAGE_VERSION}")
+endif ()
 
 # propagate SEQAN3_INCLUDE_DIR into SEQAN3_INCLUDE_DIRS
 set (SEQAN3_INCLUDE_DIRS ${SEQAN3_INCLUDE_DIR})
@@ -307,7 +311,7 @@ set (SEQAN3_INCLUDE_DIRS ${SEQAN3_INCLUDE_DIR})
 # Export targets
 # ----------------------------------------------------------------------------
 
-if (SEQAN3_FOUND AND NOT TARGET seqan3::seqan3)
+if (NOT TARGET seqan3::seqan3)
     add_library (seqan3_seqan3 INTERFACE)
     target_compile_definitions (seqan3_seqan3 INTERFACE ${SEQAN3_DEFINITIONS})
     target_compile_features (seqan3_seqan3 INTERFACE cxx_std_23)


### PR DESCRIPTION
CPM usually does a find_package redirect.
If `find_package` is called for some package added via CPM, it is redirected to CPM.

Before CPM 0.40.6, there was a bug that prevented this redirection from working properly.

If Seqan3 is added via CPM, CPM will call seqan3's `CMakeLists.txt`.
Because we use `find_package` there, it is redirected and results in seqan3 not being available.