### PR TITLE
fix: include alignment printer in debug_stream.h

### DIFF
--- a/doc/tutorial/08_pairwise_alignment/pairwise_alignment_solution_4.err
+++ b/doc/tutorial/08_pairwise_alignment/pairwise_alignment_solution_4.err
@@ -2,4 +2,8 @@ Score: 62
 Begin: (4,0)
 End: (34,31)
 Alignment: 
-(GTACGGAC-T-AGCTACAACATTACGGACTAC,GGAC-GACATGACGTACGACTTTACGTACGAC)
+      0     .    :    .    :    .    :  
+        GTACGGAC-T-AGCTACAACATTACGGACTAC
+        | || ||| | |  ||| || ||||| || ||
+        GGAC-GACATGACGTACGACTTTACGTACGAC
+

--- a/doc/tutorial/08_pairwise_alignment/pairwise_alignment_solution_5.err
+++ b/doc/tutorial/08_pairwise_alignment/pairwise_alignment_solution_5.err
@@ -2,4 +2,8 @@ Score: 62
 Begin: (4,0)
 End: (34,31)
 Alignment: 
-(GTACGGAC-T-AGCTACAACATTACGGACTAC,GGAC-GACATGACGTACGACTTTACGTACGAC)
+      0     .    :    .    :    .    :  
+        GTACGGAC-T-AGCTACAACATTACGGACTAC
+        | || ||| | |  ||| || ||||| || ||
+        GGAC-GACATGACGTACGACTTTACGTACGAC
+

--- a/include/seqan3/core/debug_stream.hpp
+++ b/include/seqan3/core/debug_stream.hpp
@@ -11,6 +11,7 @@
 
 #include <iostream>
 
+#include <seqan3/alignment/aligned_sequence/debug_stream_alignment.hpp>
 #include <seqan3/alphabet/detail/debug_stream_alphabet.hpp>
 #include <seqan3/core/debug_stream/all.hpp>
 

--- a/test/snippet/alignment/cigar_conversion/alignment_from_cigar.err
+++ b/test/snippet/alignment/cigar_conversion/alignment_from_cigar.err
@@ -1,1 +1,5 @@
-(ACTGA,AC-GA)
+      0     .
+        ACTGA
+        || ||
+        AC-GA
+

--- a/test/snippet/alignment/cigar_conversion/alignment_from_cigar_io.err
+++ b/test/snippet/alignment/cigar_conversion/alignment_from_cigar_io.err
@@ -1,3 +1,15 @@
-(ACT-,C-GT)
-(CTGATCGAG,AGGCTGN-A)
-(T-G-A-TC,G-AGTA-T)
+      0     
+        ACT-
+            
+        C-GT
+
+      0     .    
+        CTGATCGAG
+          | |    
+        AGGCTGN-A
+
+      0     .   
+        T-G-A-TC
+         |      
+        G-AGTA-T
+

--- a/test/snippet/alignment/configuration/align_cfg_output_examples.err
+++ b/test/snippet/alignment/configuration/align_cfg_output_examples.err
@@ -1,10 +1,22 @@
 {score: -4}
 {
 alignment:
-(ACGTA-G-C-,A-GTACGACG)}
+      0     .    :
+        ACGTA-G-C-
+        | ||| | | 
+        A-GTACGACG
+}
 {score: -4, 
 alignment:
-(ACGTA-G-C-,A-GTACGACG)}
+      0     .    :
+        ACGTA-G-C-
+        | ||| | | 
+        A-GTACGACG
+}
 {sequence1 id: 0, sequence2 id: 0, score: -4, begin: (0,0), end: (7,9), 
 alignment:
-(ACGTA-G-C-,A-GTACGACG)}
+      0     .    :
+        ACGTA-G-C-
+        | ||| | | 
+        A-GTACGACG
+}

--- a/test/unit/utility/views/chunk_test.cpp
+++ b/test/unit/utility/views/chunk_test.cpp
@@ -9,7 +9,6 @@
 #include <ranges>
 #include <vector>
 
-#include <seqan3/core/debug_stream.hpp>
 #include <seqan3/test/expect_range_eq.hpp>
 #include <seqan3/utility/views/chunk.hpp>
 #include <seqan3/utility/views/repeat.hpp>


### PR DESCRIPTION
includes the debug_stream_alignment.hpp in debug_stream.hpp for proper printing. see #3309 for more details on the issue.