### PR TITLE
[INFRA] Set default SEQAN3_GENERATE_SNIPPETS to OFF

### DIFF
--- a/test/analyse/CMakeLists.txt
+++ b/test/analyse/CMakeLists.txt
@@ -9,8 +9,6 @@ include (../seqan3-test.cmake)
 
 enable_testing ()
 
-option (SEQAN3_GENERATE_SNIPPETS "" OFF)
-
 add_subdirectory (../performance performance)
 add_subdirectory (../snippet snippet)
 add_subdirectory (../unit unit)

--- a/test/snippet/CMakeLists.txt
+++ b/test/snippet/CMakeLists.txt
@@ -11,7 +11,7 @@ include (../cmake/diagnostics/list_unused_snippets.cmake)
 CPMGetPackage (googletest)
 
 option (SEQAN3_GENERATE_SNIPPETS "Whether seqan3 snippets should be generated and overwritten within the source tree."
-        ON)
+        OFF)
 
 add_library (snippet_main snippet_main.cpp)
 target_link_libraries (snippet_main PUBLIC seqan3::test gtest)


### PR DESCRIPTION
<!--
Please see https://github.com/seqan/seqan3/blob/main/CONTRIBUTING.md for a general overview.

Please allow edits from maintainers:
https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests

Once you create the PR, clang-format will be run on the PR, and any formatting changes will be pushed to your fork.
Subsequently, the actual CI will start.

****************************************************************************************************
** Attention: This means that you will have to `git pull` the changes before pushing new commits. **
****************************************************************************************************

Each of your commits will trigger a clang-format commit if there are formatting changes.


While the following guide on rebasing formatting changes is intended for internal use by SeqAn members, and in no way
necessary for contributors, it may still be an interesting read: https://github.com/seqan/seqan3/wiki/Rebasing-clang-format-commits-with-git-absorb
-->
