### PR TITLE
[MISC] Separate Bloom Filter strong types

### DIFF
--- a/include/seqan3/search/dream_index/interleaved_bloom_filter.hpp
+++ b/include/seqan3/search/dream_index/interleaved_bloom_filter.hpp
@@ -14,47 +14,13 @@
 
 #include <seqan3/contrib/sdsl-lite.hpp>
 #include <seqan3/core/concept/cereal.hpp>
-#include <seqan3/core/detail/strong_type.hpp>
+//Todo: When removing, the contents of the following header can be moved into utility/bloom_filter/bloom_filter.hpp
+#include <seqan3/utility/bloom_filter/bloom_filter_strong_types.hpp>
 
 SEQAN3_DEPRECATED_HEADER("This header and its functionality is deprecated and will be removed in a future version of SeqAn. Please use the hibf-library (url: https://github.com/seqan/hibf) instead.");
 
 namespace seqan3
 {
-//!\brief Determines if the Interleaved Bloom Filter is compressed.
-//!\ingroup search_dream_index
-enum data_layout : bool
-{
-    uncompressed, //!< The Interleaved Bloom Filter is uncompressed.
-    compressed    //!< The Interleaved Bloom Filter is compressed.
-};
-
-//!\brief A strong type that represents the number of bins for the seqan3::interleaved_bloom_filter.
-//!\ingroup search_dream_index
-struct bin_count : public detail::strong_type<size_t, bin_count, detail::strong_type_skill::convert>
-{
-    using detail::strong_type<size_t, bin_count, detail::strong_type_skill::convert>::strong_type;
-};
-
-//!\brief A strong type that represents the number of bits for each bin in the seqan3::interleaved_bloom_filter.
-//!\ingroup search_dream_index
-struct bin_size : public detail::strong_type<size_t, bin_size, detail::strong_type_skill::convert>
-{
-    using detail::strong_type<size_t, bin_size, detail::strong_type_skill::convert>::strong_type;
-};
-
-//!\brief A strong type that represents the number of hash functions for the seqan3::interleaved_bloom_filter.
-//!\ingroup search_dream_index
-struct hash_function_count : public detail::strong_type<size_t, hash_function_count, detail::strong_type_skill::convert>
-{
-    using detail::strong_type<size_t, hash_function_count, detail::strong_type_skill::convert>::strong_type;
-};
-
-//!\brief A strong type that represents the bin index for the seqan3::interleaved_bloom_filter.
-//!\ingroup search_dream_index
-struct bin_index : public detail::strong_type<size_t, bin_index, detail::strong_type_skill::convert>
-{
-    using detail::strong_type<size_t, bin_index, detail::strong_type_skill::convert>::strong_type;
-};
 
 /*!\brief The IBF binning directory. A data structure that efficiently answers set-membership queries for multiple bins.
  * \ingroup search_dream_index

--- a/include/seqan3/utility/bloom_filter/bloom_filter.hpp
+++ b/include/seqan3/utility/bloom_filter/bloom_filter.hpp
@@ -9,7 +9,11 @@
 
 #pragma once
 
-#include <seqan3/search/dream_index/interleaved_bloom_filter.hpp>
+#include <seqan3/contrib/sdsl-lite.hpp>
+#include <seqan3/core/concept/cereal.hpp>
+//Todo: When removing search/dream_index/interleaved_bloom_filter.hpp, the contents of the following header can be
+// moved into this file
+#include <seqan3/utility/bloom_filter/bloom_filter_strong_types.hpp>
 
 namespace seqan3
 {

--- a/include/seqan3/utility/bloom_filter/bloom_filter_strong_types.hpp
+++ b/include/seqan3/utility/bloom_filter/bloom_filter_strong_types.hpp
@@ -1,0 +1,56 @@
+// SPDX-FileCopyrightText: 2006-2025 Knut Reinert & Freie Universität Berlin
+// SPDX-FileCopyrightText: 2016-2025 Knut Reinert & MPI für molekulare Genetik
+// SPDX-License-Identifier: BSD-3-Clause
+
+/*!\file
+ * \author Enrico Seiler <enrico.seiler AT fu-berlin.de>
+ * \brief Provides strong types for the (Interleaved) Bloom Filter.
+ */
+
+#pragma once
+
+#include <seqan3/core/detail/strong_type.hpp>
+
+//Todo: When removing search/dream_index/interleaved_bloom_filter.hpp, the contents of this header can be moved
+// into utility/bloom_filter/bloom_filter.hpp
+
+namespace seqan3
+{
+
+//!\brief Determines if the Interleaved Bloom Filter is compressed.
+//!\ingroup utility_bloom_filter
+enum data_layout : bool
+{
+    uncompressed, //!< The Interleaved Bloom Filter is uncompressed.
+    compressed    //!< The Interleaved Bloom Filter is compressed.
+};
+
+//!\brief A strong type that represents the number of bins for the seqan3::interleaved_bloom_filter.
+//!\ingroup utility_bloom_filter
+struct bin_count : public detail::strong_type<size_t, bin_count, detail::strong_type_skill::convert>
+{
+    using detail::strong_type<size_t, bin_count, detail::strong_type_skill::convert>::strong_type;
+};
+
+//!\brief A strong type that represents the number of bits for each bin in the seqan3::interleaved_bloom_filter.
+//!\ingroup utility_bloom_filter
+struct bin_size : public detail::strong_type<size_t, bin_size, detail::strong_type_skill::convert>
+{
+    using detail::strong_type<size_t, bin_size, detail::strong_type_skill::convert>::strong_type;
+};
+
+//!\brief A strong type that represents the number of hash functions for the seqan3::interleaved_bloom_filter.
+//!\ingroup utility_bloom_filter
+struct hash_function_count : public detail::strong_type<size_t, hash_function_count, detail::strong_type_skill::convert>
+{
+    using detail::strong_type<size_t, hash_function_count, detail::strong_type_skill::convert>::strong_type;
+};
+
+//!\brief A strong type that represents the bin index for the seqan3::interleaved_bloom_filter.
+//!\ingroup utility_bloom_filter
+struct bin_index : public detail::strong_type<size_t, bin_index, detail::strong_type_skill::convert>
+{
+    using detail::strong_type<size_t, bin_index, detail::strong_type_skill::convert>::strong_type;
+};
+
+} // namespace seqan3


### PR DESCRIPTION
Such that including the bloom_filter does not trigger deprecation warnings

<!--
Please see https://github.com/seqan/seqan3/blob/main/CONTRIBUTING.md for a general overview.

Please allow edits from maintainers:
https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests

Once you create the PR, clang-format will be run on the PR, and any formatting changes will be pushed to your fork.
Subsequently, the actual CI will start.

****************************************************************************************************
** Attention: This means that you will have to `git pull` the changes before pushing new commits. **
****************************************************************************************************

Each of your commits will trigger a clang-format commit if there are formatting changes.


While the following guide on rebasing formatting changes is intended for internal use by SeqAn members, and in no way
necessary for contributors, it may still be an interesting read: https://github.com/seqan/seqan3/wiki/Rebasing-clang-format-commits-with-git-absorb
-->
