### PR TITLE
[FIX] gcc15: conditionally borrowed_range views

### DIFF
--- a/include/seqan3/io/views/detail/take_exactly_view.hpp
+++ b/include/seqan3/io/views/detail/take_exactly_view.hpp
@@ -549,6 +549,7 @@ namespace seqan3::detail
  * | std::ranges::sized_range         |                                       | ***guaranteed***                                   |
  * | std::ranges::common_range        |                                       | *preserved*                                        |
  * | std::ranges::output_range        |                                       | *preserved* except if `urng_t` is std::basic_string|
+ * | std::ranges::borrowed_range      |                                       | *preserved*                                        |
  * | seqan3::const_iterable_range     |                                       | *preserved*                                        |
  * |                                  |                                       |                                                    |
  * | std::ranges::range_reference_t   |                                       | std::ranges::range_reference_t<urng_t>             |
@@ -586,3 +587,12 @@ inline constexpr auto take_exactly = take_exactly_fn<false>{};
  */
 inline constexpr auto take_exactly_or_throw = take_exactly_fn<true>{};
 } // namespace seqan3::detail
+
+namespace std::ranges
+{
+//!\cond
+template <std::ranges::view urng_t, bool or_throw>
+inline constexpr bool enable_borrowed_range<seqan3::detail::view_take_exactly<urng_t, or_throw>> =
+    enable_borrowed_range<urng_t>;
+//!\endcond
+} // namespace std::ranges

--- a/include/seqan3/io/views/detail/take_until_view.hpp
+++ b/include/seqan3/io/views/detail/take_until_view.hpp
@@ -531,6 +531,7 @@ namespace seqan3::detail
  * | std::ranges::sized_range         |                                       | *lost*                                             |
  * | std::ranges::common_range        |                                       | *lost*                                             |
  * | std::ranges::output_range        |                                       | *preserved*                                        |
+ * | std::ranges::borrowed_range      |                                       | *preserved*                                        |
  * | seqan3::const_iterable_range     |                                       | <i>preserved</i>¹                                  |
  * |                                  |                                       |                                                    |
  * | std::ranges::range_reference_t   |                                       | std::ranges::range_reference_t<urng_t>             |
@@ -602,3 +603,12 @@ inline constexpr auto take_until_and_consume = take_until_fn<false, true>{};
 inline constexpr auto take_until_or_throw_and_consume = take_until_fn<true, true>{};
 
 } // namespace seqan3::detail
+
+namespace std::ranges
+{
+//!\cond
+template <std::ranges::view urng_t, typename fun_t, bool or_throw, bool and_consume>
+inline constexpr bool enable_borrowed_range<seqan3::detail::view_take_until<urng_t, fun_t, or_throw, and_consume>> =
+    enable_borrowed_range<urng_t>;
+//!\endcond
+} // namespace std::ranges

--- a/include/seqan3/utility/views/single_pass_input.hpp
+++ b/include/seqan3/utility/views/single_pass_input.hpp
@@ -327,6 +327,7 @@ namespace seqan3::views
  * | std::ranges::sized_range         |                                       | *lost*                                             |
  * | std::ranges::common_range        |                                       | *lost*                                             |
  * | std::ranges::output_range        |                                       | *lost*                                             |
+ * | std::ranges::borrowed_range      |                                       | *preserved*                                        |
  * | seqan3::const_iterable_range     |                                       | *lost*                                             |
  * |                                  |                                       |                                                    |
  * | std::ranges::range_reference_t   |                                       | std::ranges::range_reference_t<urng_t>             |
@@ -346,3 +347,12 @@ inline constexpr auto single_pass_input = detail::adaptor_for_view_without_args<
 
 } // namespace seqan3::views
 //![adaptor_def]
+
+namespace std::ranges
+{
+//!\cond
+template <std::ranges::view urng_t>
+inline constexpr bool enable_borrowed_range<seqan3::detail::single_pass_input_view<urng_t>> =
+    enable_borrowed_range<urng_t>;
+//!\endcond
+} // namespace std::ranges

--- a/test/unit/io/views/detail/take_exactly_view_test.cpp
+++ b/test/unit/io/views/detail/take_exactly_view_test.cpp
@@ -69,6 +69,8 @@ void do_concepts(adaptor_t && adaptor, bool const exactly)
     EXPECT_TRUE(std::ranges::common_range<decltype(v1)>);
     EXPECT_TRUE(seqan3::const_iterable_range<decltype(v1)>);
     EXPECT_TRUE((std::ranges::output_range<decltype(v1), int>));
+    EXPECT_TRUE(std::ranges::borrowed_range<decltype(v1)>);
+    EXPECT_TRUE(std::ranges::borrowed_range<decltype(vec | adaptor)>);
 
     auto v3 = vec
             | std::views::transform(
@@ -101,6 +103,8 @@ void do_concepts(adaptor_t && adaptor, bool const exactly)
     EXPECT_FALSE(std::ranges::common_range<decltype(v2)>);
     EXPECT_FALSE(seqan3::const_iterable_range<decltype(v2)>);
     EXPECT_FALSE((std::ranges::output_range<decltype(v2), int>));
+    EXPECT_TRUE(std::ranges::borrowed_range<decltype(v2)>);
+    EXPECT_TRUE(std::ranges::borrowed_range<decltype(vec | seqan3::views::single_pass_input | adaptor)>);
 
     // explicit test for non const-iterable views
     // https://github.com/seqan/seqan3/pull/1734#discussion_r408829267

--- a/test/unit/io/views/detail/take_until_view_test.cpp
+++ b/test/unit/io/views/detail/take_until_view_test.cpp
@@ -65,6 +65,8 @@ void do_concepts(adaptor_t && adaptor, bool const_it)
     EXPECT_FALSE(std::ranges::common_range<decltype(v1)>);
     EXPECT_EQ(seqan3::const_iterable_range<decltype(v1)>, const_it);
     EXPECT_TRUE((std::ranges::output_range<decltype(v1), char>));
+    EXPECT_TRUE(std::ranges::borrowed_range<decltype(v1)>);
+    EXPECT_TRUE(std::ranges::borrowed_range<decltype(vec | adaptor)>);
 
     auto v2 = vec | seqan3::views::single_pass_input | adaptor;
 
@@ -77,6 +79,8 @@ void do_concepts(adaptor_t && adaptor, bool const_it)
     EXPECT_FALSE(std::ranges::common_range<decltype(v2)>);
     EXPECT_FALSE(seqan3::const_iterable_range<decltype(v2)>);
     EXPECT_FALSE((std::ranges::output_range<decltype(v2), char>)); // lost by single_pass_input
+    EXPECT_TRUE(std::ranges::borrowed_range<decltype(v2)>);
+    EXPECT_TRUE(std::ranges::borrowed_range<decltype(vec | seqan3::views::single_pass_input | adaptor)>);
 
     // explicit test for non const-iterable views
     // https://github.com/seqan/seqan3/pull/1734#discussion_r408829267


### PR DESCRIPTION
gcc15 now implements `std::ranges::to`

For `std::string` (as example), the call is delegated to `std::string(std::from_range, R &&)`.
This then will use `std::ranges::data` to get the data pointer and just copy the data.

This happens, for example, in format_sam's `id | detail::take_until_and_consume(is_space) | ranges::to<id_type>()`. 
Since the view is not an lvalue, it needs to be a borrowed_range for `std::ranges::data` to work.

Similar to std::views, we make (some of) our views conditionally borrowed if the underlying range is borrowed.