### PR TITLE
[FIX,INFRA] cmake: version variables cannot be forced

### DIFF
--- a/.github/workflows/cron_debian.yml
+++ b/.github/workflows/cron_debian.yml
@@ -37,7 +37,7 @@ jobs:
         id: source_package
         run: |
           mkdir source && cd source
-          git clone --depth 1 https://github.com/seqan/seqan3.git
+          git clone --depth 1 --branch "${{ github.ref_name }}" https://github.com/${{ github.repository }}.git
           mkdir package && cd package
           cmake ../seqan3
           make package_source

--- a/cmake/package-lock.cmake
+++ b/cmake/package-lock.cmake
@@ -13,10 +13,17 @@
 # Ideally, both are the same, which might not always be possible: https://github.com/cpm-cmake/CPM.cmake/issues/603
 # This is needed to support CPM_USE_LOCAL_PACKAGES
 
+# Each package has a (project-prefixed) version variable, which allows changing the version of a package without
+# changing the package lock file.
+# This is useful for packaging, where there might only be an older version, e.g. of googletest, available.
+# Note that the variable has to be a cache variable to work properly, but not a forced cache variable.
+# A clean reconfigure, i.e. deleting CMakeCache.txt, is needed to update the default version in an existing
+# build directory.
+
 # cmake-format: off
 
 # cereal
-set (SEQAN3_CEREAL_VERSION 1.3.2 CACHE STRING "" FORCE)
+set (SEQAN3_CEREAL_VERSION 1.3.2 CACHE STRING "")
 CPMDeclarePackage (cereal
                    NAME cereal
                    VERSION ${SEQAN3_CEREAL_VERSION}
@@ -24,7 +31,7 @@ CPMDeclarePackage (cereal
                    SYSTEM TRUE
                    OPTIONS "JUST_INSTALL_CEREAL ON" "CMAKE_MESSAGE_LOG_LEVEL WARNING")
 # benchmark
-set (SEQAN3_BENCHMARK_VERSION 1.9.2 CACHE STRING "" FORCE)
+set (SEQAN3_BENCHMARK_VERSION 1.9.2 CACHE STRING "")
 CPMDeclarePackage (benchmark
                    NAME benchmark
                    VERSION ${SEQAN3_BENCHMARK_VERSION}
@@ -33,7 +40,7 @@ CPMDeclarePackage (benchmark
                    OPTIONS "BENCHMARK_ENABLE_TESTING OFF" "BENCHMARK_ENABLE_WERROR OFF"
                            "CMAKE_MESSAGE_LOG_LEVEL WARNING")
 # googletest
-set (SEQAN3_GOOGLETEST_VERSION 1.16.0 CACHE STRING "" FORCE)
+set (SEQAN3_GOOGLETEST_VERSION 1.16.0 CACHE STRING "")
 CPMDeclarePackage (googletest
                    NAME GTest
                    VERSION ${SEQAN3_GOOGLETEST_VERSION}
@@ -41,7 +48,7 @@ CPMDeclarePackage (googletest
                    SYSTEM TRUE
                    OPTIONS "BUILD_GMOCK OFF" "INSTALL_GTEST OFF" "CMAKE_MESSAGE_LOG_LEVEL WARNING")
 # doxygen-awesome
-set (SEQAN3_DOXYGEN_AWESOME_VERSION 2.3.4 CACHE STRING "" FORCE)
+set (SEQAN3_DOXYGEN_AWESOME_VERSION 2.3.4 CACHE STRING "")
 CPMDeclarePackage (doxygen_awesome
                    NAME doxygen_awesome
                    VERSION ${SEQAN3_DOXYGEN_AWESOME_VERSION}
@@ -49,7 +56,7 @@ CPMDeclarePackage (doxygen_awesome
                    DOWNLOAD_ONLY TRUE
                    QUIET TRUE)
 # seqan2
-set (SEQAN3_SEQAN2_VERSION 2.5.0 CACHE STRING "" FORCE)
+set (SEQAN3_SEQAN2_VERSION 2.5.0 CACHE STRING "")
 CPMDeclarePackage (seqan
                    NAME seqan
                    VERSION ${SEQAN3_SEQAN2_VERSION}
@@ -58,7 +65,7 @@ CPMDeclarePackage (seqan
                    DOWNLOAD_ONLY TRUE
                    QUIET TRUE)
 # use_ccache
-set (SEQAN3_USE_CCACHE_VERSION d2a54ef555b6fc2d496a4c9506dbeb7cf899ce37 CACHE STRING "" FORCE)
+set (SEQAN3_USE_CCACHE_VERSION d2a54ef555b6fc2d496a4c9506dbeb7cf899ce37 CACHE STRING "")
 CPMDeclarePackage (use_ccache
                    NAME use_ccache
                    GIT_TAG ${SEQAN3_USE_CCACHE_VERSION} # main


### PR DESCRIPTION
Forced cache will cause the variable to be always set to the value defined in the package lock.
We actually want to be able to overwrite this.

Preferably, we would like to
* Overwrite if given on CLI. Otherwise, use default.
* On reconfigure, revert to default if not given.
* Have the variables available in the parent project (CPM version update script).

This doesn't really seem possible, see https://github.com/eseiler/misc/tree/main/cmake_set for some examples.

The drawback of `CACHE` is that changed default versions are not honored on a simple reconfigure.