### PR TITLE
[WIP] append to sequence file output

### DIFF
--- a/include/seqan3/io/sequence_file/output.hpp
+++ b/include/seqan3/io/sequence_file/output.hpp
@@ -146,12 +146,14 @@ public:
      * See the section on \link io_compression compression and decompression \endlink for more information.
      */
     sequence_file_output(std::filesystem::path filename,
-                         selected_field_ids const & SEQAN3_DOXYGEN_ONLY(fields_tag) = selected_field_ids{}) :
+                         selected_field_ids const & SEQAN3_DOXYGEN_ONLY(fields_tag) = selected_field_ids{},
+                         sequence_file_output_options output_options = sequence_file_output_options{}) :
+        options{std::move(output_options)},
         primary_stream{new std::ofstream{}, stream_deleter_default}
     {
         primary_stream->rdbuf()->pubsetbuf(stream_buffer.data(), stream_buffer.size());
         static_cast<std::basic_ofstream<char> *>(primary_stream.get())
-            ->open(filename, std::ios_base::out | std::ios::binary);
+            ->open(filename, (options.append ? std::ios_base::app : std::ios_base::out) | std::ios::binary);
 
         if (!primary_stream->good())
             throw file_open_error{"Could not open file " + filename.string() + " for writing."};

--- a/include/seqan3/io/sequence_file/output_options.hpp
+++ b/include/seqan3/io/sequence_file/output_options.hpp
@@ -40,6 +40,9 @@ struct sequence_file_output_options
 
     //!\brief Complete header given for embl or genbank
     bool embl_genbank_complete_header = false;
+
+    //!\brief Whether to open the file in append mode.
+    bool append = false;
 };
 
 } // namespace seqan3


### PR DESCRIPTION
Example usage:

```cpp
seqan3::sequence_file_output fout{"/tmp/test.sam",
                                  seqan3::fields<seqan3::field::id, seqan3::field::seq, seqan3::field::qual>{},
                                  {.append = true}};
```

* It's annoying, but acceptable, that the fields have to be given.
* I just reused `sequence_file_output_options` for this because I didn't want to add another enum/strong type.
* `sequence_file_output_options::append` is the only option that's fixed on construction

```cpp
seqan3::sequence_file_output fout{"/tmp/test.sam",
                                  seqan3::fields<seqan3::field::id, seqan3::field::seq, seqan3::field::qual>{},
                                  {.append = true}};
fout.options.append = false; // No effect
```
```cpp
seqan3::sequence_file_output fout{"/tmp/test.sam",
                                  seqan3::fields<seqan3::field::id, seqan3::field::seq, seqan3::field::qual>{}};
fout.options.append = true; // No effect
```