### PR TITLE
chore(deps): update CPM packages

### DIFF
--- a/cmake/package-lock.cmake
+++ b/cmake/package-lock.cmake
@@ -40,7 +40,7 @@ CPMDeclarePackage (benchmark
                    OPTIONS "BENCHMARK_ENABLE_TESTING OFF" "BENCHMARK_ENABLE_WERROR OFF"
                            "CMAKE_MESSAGE_LOG_LEVEL WARNING")
 # googletest
-set (SEQAN3_GOOGLETEST_VERSION 1.17.0 CACHE STRING "")
+set (SEQAN3_GOOGLETEST_VERSION 1.18.0 CACHE STRING "")
 CPMDeclarePackage (googletest
                    NAME GTest
                    VERSION ${SEQAN3_GOOGLETEST_VERSION}

--- a/test/unit/io/sam_file/sam_file_seek_test.cpp
+++ b/test/unit/io/sam_file/sam_file_seek_test.cpp
@@ -16,7 +16,10 @@
 #include <seqan3/test/fixture/io/sam_file/simple_three_verbose_reads_fixture.hpp>
 #include <seqan3/test/pretty_printing.hpp>
 
-using sam_file_seek_test_fixture = std::tuple<std::filesystem::path, std::vector<std::streampos>>;
+// GCC 14 on macOS runs into an internal compiler error when googletest's parameterised test machinery is
+// instantiated with a parameter type that carries an ABI tag, e.g. std::filesystem::path or std::string, also when
+// nested inside a std::tuple. std::string_view carries no ABI tag and converts to std::filesystem::path in SetUp().
+using sam_file_seek_test_fixture = std::tuple<std::string_view, std::vector<std::streampos>>;
 
 struct sam_file_seek_test : public ::testing::TestWithParam<sam_file_seek_test_fixture>
 {

--- a/test/unit/io/sequence_file/sequence_file_seek_test.cpp
+++ b/test/unit/io/sequence_file/sequence_file_seek_test.cpp
@@ -16,7 +16,10 @@
 #include <seqan3/test/fixture/io/sequence_file/standard_fixture.hpp>
 #include <seqan3/test/pretty_printing.hpp>
 
-using sequence_file_seek_test_fixture = std::tuple<std::filesystem::path /*sequence_file_path*/,
+// GCC 14 on macOS runs into an internal compiler error when googletest's parameterised test machinery is
+// instantiated with a parameter type that carries an ABI tag, e.g. std::filesystem::path or std::string, also when
+// nested inside a std::tuple. std::string_view carries no ABI tag and converts to std::filesystem::path in SetUp().
+using sequence_file_seek_test_fixture = std::tuple<std::string_view /*sequence_file_path*/,
                                                    bool /*has_base_qualities*/,
                                                    std::vector<std::streampos> /*file_positions*/>;
 


### PR DESCRIPTION
## ICE on macOS gcc-14
The ICE is not about `std::streampos` or the seek tests specifically — it's GCC 14's handling of **ABI-tagged types as the googletest parameter type**. This reproduces standalone in 4 lines:

```cpp
#include <gtest/gtest.h>
struct t1 : public ::testing::TestWithParam<std::string> {};   // ICE
TEST_P(t1, foo) {}
INSTANTIATE_TEST_SUITE_P(s, t1, ::testing::Values(std::string{"a"}));
```

`std::string`, `std::wstring`, `std::filesystem::path`, and a hand-rolled struct `__attribute__((abi_tag("cxx11")))` all ICE; `int`, `double`, `std::vector<int>`, `std::vector<std::streampos>`, `char const *`, `std::string_view` and plain structs (even ones containing a `std::string`) all compile fine.
It's the tag on the top-level `T` that matters, whether `T` is the tagged type itself or a `std::tuple` containing one. It's gcc-14 only — g++-15 and g++-16 on this machine are fine, as is clang. Not a compiler stack overflow (`ulimit -s 65520` changes nothing).