### PR TITLE
fix: pairwise_combine_view

### DIFF
--- a/include/seqan3/utility/tuple/concept.hpp
+++ b/include/seqan3/utility/tuple/concept.hpp
@@ -102,7 +102,7 @@ template <typename tuple_t>
     requires requires () {
         { detail::all_elements_model_totally_ordered(tuple_type_list_t<tuple_t>{}) };
     }
-static constexpr bool all_elements_model_totally_ordered_v =
+inline constexpr bool all_elements_model_totally_ordered_v =
     decltype(detail::all_elements_model_totally_ordered(tuple_type_list_t<tuple_t>{}))::value;
 } // namespace seqan3::detail
 

--- a/include/seqan3/utility/views/pairwise_combine.hpp
+++ b/include/seqan3/utility/views/pairwise_combine.hpp
@@ -273,8 +273,15 @@ public:
     using reference = common_tuple<underlying_ref_t, underlying_ref_t>;
     //!\brief The pointer type.
     using pointer = void;
-    //!\brief The iterator concept tag.
-    using iterator_concept = detail::iterator_concept_tag_t<underlying_iterator_type>;
+    /*!\brief The iterator concept tag.
+     * \details
+     *
+     * This iterator returns a prvalue proxy (seqan3::common_tuple) and can therefore never be contiguous, even if
+     * the `underlying_iterator_type` is. In that case, the concept is downgraded to std::random_access_iterator_tag.
+     */
+    using iterator_concept = std::conditional_t<std::contiguous_iterator<underlying_iterator_type>,
+                                                std::random_access_iterator_tag,
+                                                detail::iterator_concept_tag_t<underlying_iterator_type>>;
     //!\}
 
     /*!\name Constructors, destructor and assignment


### PR DESCRIPTION
Summary via Claude

Resolves #2747 
Resolves #2905 

---

https://github.com/seqan/seqan3/blob/944c600a7de54393a0f196360eaba5efe4a824b9/include/seqan3/utility/views/pairwise_combine.hpp#L277

`pairwise_combine.hpp:277` declared `iterator_concept = detail::iterator_concept_tag_t<underlying_iterator_type>`, propagating the underlying iterator's tag verbatim. Over a `std::vector<char>` that is `std::contiguous_iterator_tag` — but `basic_iterator` dereferences to a `common_tuple<char&, char&>` prvalue proxy, so it is at most random-access. The tag was simply wrong.

It went unnoticed until clang-23: libc++'s new `std::__assume_valid_range` (called from `__find_if`, reached here via `filter_view::begin`) checks `__has_iterator_concept_convertible_to<_Iter, contiguous_iterator_tag>` and, believing the claim, calls `std::__to_address(__first)` — which has no viable overload for the proxy iterator.

Fix: cap the tag at `random_access_iterator_tag` when the underlying iterator is contiguous, matching the pattern already used in `kmer_hash.hpp:253-255`

https://github.com/seqan/seqan3/blob/944c600a7de54393a0f196360eaba5efe4a824b9/include/seqan3/search/views/kmer_hash.hpp#L253-L255

`iterator_category` needed no change: it comes from `maybe_iterator_category`, and libc++'s `iterator_traits<T*>::iterator_category` is already `random_access_iterator_tag`.