### PR TITLE
fix(clang-23): missing includes

### DIFF
--- a/include/seqan3/alphabet/nucleotide/dna16sam.hpp
+++ b/include/seqan3/alphabet/nucleotide/dna16sam.hpp
@@ -9,6 +9,8 @@
 
 #pragma once
 
+#include <vector>
+
 #include <seqan3/alphabet/nucleotide/nucleotide_base.hpp>
 
 namespace seqan3

--- a/include/seqan3/alphabet/quality/phred42.hpp
+++ b/include/seqan3/alphabet/quality/phred42.hpp
@@ -9,6 +9,8 @@
 
 #pragma once
 
+#include <vector>
+
 #include <seqan3/alphabet/quality/phred_base.hpp>
 
 namespace seqan3

--- a/include/seqan3/alphabet/quality/phred63.hpp
+++ b/include/seqan3/alphabet/quality/phred63.hpp
@@ -9,6 +9,8 @@
 
 #pragma once
 
+#include <vector>
+
 #include <seqan3/alphabet/quality/phred_base.hpp>
 
 namespace seqan3

--- a/include/seqan3/alphabet/quality/phred68solexa.hpp
+++ b/include/seqan3/alphabet/quality/phred68solexa.hpp
@@ -9,6 +9,8 @@
 
 #pragma once
 
+#include <vector>
+
 #include <seqan3/alphabet/quality/phred_base.hpp>
 
 namespace seqan3

--- a/include/seqan3/alphabet/quality/phred94.hpp
+++ b/include/seqan3/alphabet/quality/phred94.hpp
@@ -9,6 +9,8 @@
 
 #pragma once
 
+#include <vector>
+
 #include <seqan3/alphabet/quality/phred_base.hpp>
 
 namespace seqan3

--- a/include/seqan3/io/record.hpp
+++ b/include/seqan3/io/record.hpp
@@ -11,6 +11,7 @@
 
 #include <limits>
 #include <tuple>
+#include <vector>
 
 #include <seqan3/core/detail/template_inspection.hpp>
 

--- a/include/seqan3/io/sam_file/detail/cigar.hpp
+++ b/include/seqan3/io/sam_file/detail/cigar.hpp
@@ -14,6 +14,7 @@
 #include <concepts>
 #include <ranges>
 #include <sstream>
+#include <vector>
 
 #include <seqan3/alignment/detail/pairwise_alignment_concept.hpp>
 #include <seqan3/alphabet/cigar/cigar.hpp>

--- a/include/seqan3/io/sam_file/sam_tag_dictionary.hpp
+++ b/include/seqan3/io/sam_file/sam_tag_dictionary.hpp
@@ -10,8 +10,10 @@
 #pragma once
 
 #include <concepts>
+#include <cstddef>
 #include <map>
 #include <variant>
+#include <vector>
 
 #include <seqan3/core/detail/template_inspection.hpp>
 #include <seqan3/utility/char_operations/predicate.hpp>

--- a/test/snippet/utility/simd/simd_load.cpp
+++ b/test/snippet/utility/simd/simd_load.cpp
@@ -2,6 +2,8 @@
 // SPDX-FileCopyrightText: 2016-2026 Knut Reinert & MPI für molekulare Genetik
 // SPDX-License-Identifier: CC0-1.0
 
+#include <vector>
+
 #include <seqan3/core/debug_stream.hpp>
 #include <seqan3/utility/simd/all.hpp>
 #include <seqan3/utility/simd/detail/debug_stream_simd.hpp>

--- a/test/snippet/utility/simd/simd_store.cpp
+++ b/test/snippet/utility/simd/simd_store.cpp
@@ -2,6 +2,8 @@
 // SPDX-FileCopyrightText: 2016-2026 Knut Reinert & MPI für molekulare Genetik
 // SPDX-License-Identifier: CC0-1.0
 
+#include <vector>
+
 #include <seqan3/core/debug_stream.hpp>
 #include <seqan3/utility/simd/all.hpp>
 


### PR DESCRIPTION
Only missing if optional dependencies (zlib, bzip2, cereal) are not used.